### PR TITLE
Add SYS_Time which returns ticks since 2000

### DIFF
--- a/gc/ogc/system.h
+++ b/gc/ogc/system.h
@@ -335,6 +335,12 @@ u32 SYS_GetArena2Size();
 powercallback SYS_SetPowerCallback(powercallback cb);
 #endif
 
+/* \fn u64 SYS_Time()
+\brief Returns the current time in ticks since 2000 (proper Dolphin/Wii time)
+\return ticks since 2000
+*/
+u64 SYS_Time();
+
 void kprintf(const char *str, ...);
 
 #ifdef __cplusplus

--- a/libogc/system.c
+++ b/libogc/system.c
@@ -1706,3 +1706,19 @@ u32 SYS_GetHollywoodRevision()
 }
 #endif
 
+extern u64 gettime();
+
+u64 SYS_Time()
+{
+	u64 current_time = gettime();
+#ifdef HW_RVL
+	u32 bias;
+	if (CONF_GetCounterBias(&bias) >= 0)
+		current_time += bias;
+#else
+	syssram* sram = __SYS_LockSram();
+	current_time += sram->counter_bias;
+	__SYS_UnlockSram(0);
+#endif
+	return current_time;
+}


### PR DESCRIPTION
 Useful for GC/Wii specific tasks, e.g: Gamecube saves, playrecord