### PR TITLE
Fix for clock_gettime and gettimeoftheday

### DIFF
--- a/libogc/timesupp.c
+++ b/libogc/timesupp.c
@@ -163,7 +163,7 @@ int clock_gettime(struct timespec *tp)
 	gctime += 946684800;
 
 	tp->tv_sec = gctime;
-	tp->tv_nsec = ticks_to_nanosecs(gettick());
+	tp->tv_nsec = ticks_to_nanosecs(gettick())%1000000000;
 
 	return 0;
 }
@@ -319,7 +319,7 @@ int __libogc_gettod_r(struct _reent *ptr, struct timeval *tp, struct timezone *t
 
 	if (tp != NULL) {
 		tp->tv_sec = time(NULL);
-		tp->tv_usec = tick_microsecs(gettick());
+		tp->tv_usec = ticks_to_microsecs(gettick())%1000000;
 	}
 	if (tz != NULL) {
 		tz->tz_minuteswest = 0;


### PR DESCRIPTION
tp->tv_nsec and tp->tv_usec should define the number of nanosecs and microsecs elapsed and their value should not be more than 1 second.

In lwp_watchdog.h tick_microsecs is defined as 

#define tick_microsecs(ticks) ((((u64)(ticks)*8)%(u64)(TB_TIMER_CLOCK/125)))

TB_TIMER_CLOCK/125 is 486. It means that the gives the rest of 486 which is wrong.

The correct function is "ticks_to_microsecs".

Anyhow also with these fixes gettimeoftheday() and clock_gettime() are not fully correct.

The result of tv_sec is correct for both, reppresenting the number of seconds since 00:00 hours, Jan 1, 1970 UTC.

tv_nsec in clock_gettime and tv_usec in __libogc_gettod_r should be respectively the number of nanoseconds and microseconds expired in the current second but instead they are values taken from the internal CPU timer which is not aligned with the RTC timer of the WII. 
