### PR TITLE
Fixed Wii U PRO controller min and max calibration

### DIFF
--- a/wiiuse/classic.c
+++ b/wiiuse/classic.c
@@ -74,8 +74,8 @@ int classic_ctrl_handshake(struct wiimote_t* wm, struct classic_ctrl_t* cc, ubyt
 
 	/* is this a wiiu pro? */
 	if (len > 223 && data[223] == 0x20) {
-		cc->ljs.max.x = cc->ljs.max.y = 0xFF;
-		cc->ljs.min.x = cc->ljs.min.y = 0;
+		cc->ljs.max.x = cc->ljs.max.y = 208;
+		cc->ljs.min.x = cc->ljs.min.y = 48;
 		cc->ljs.center.x = cc->ljs.center.y = 0x80;
 
 		cc->rjs = cc->ljs;


### PR DESCRIPTION
The Wii U Pro controller does not provide calibration data therefore these data have been written in the code (classic.c).

However the min and max values (0 and 0xFF) are not correct and far from the real values.
More convenient values should be min=48 and max=208.
These values come from testing 2 Wii U Pro controller

Wrong calibration data lead to wrong polar coordinates values (in particular exp.classic.ljs.mag).