### PR TITLE
- Add net_gethostip and net_get_mac_address for GameCube

### DIFF
--- a/gc/network.h
+++ b/gc/network.h
@@ -254,8 +254,8 @@ typedef s32 (*netcallback)(s32 result, void *usrdata);
 s32 net_init_async(netcallback cb, void *usrdata);
 s32 net_get_status(void);
 void net_wc24cleanup();
-s32 net_get_mac_address(void *mac_buf);
 #endif
+s32 net_get_mac_address(void *mac_buf);
 void net_deinit();
 
 u32 net_gethostip();

--- a/lwip/network.c
+++ b/lwip/network.c
@@ -1576,6 +1576,19 @@ s32 if_config(char *local_ip, char *netmask, char *gateway,bool use_dhcp, int ma
 }
 
 
+u32 net_gethostip(void)
+{
+	return g_hNetIF.ip_addr.addr;
+}
+
+s32 net_get_mac_address(void *mac_buf)
+{
+	if(mac_buf==NULL) return -EINVAL;
+	memcpy(mac_buf,g_hNetIF.hwaddr,g_hNetIF.hwaddr_len);
+	return 0;
+}
+
+
 s32 net_init()
 {
 	sys_sem sem;


### PR DESCRIPTION
Originally from: https://github.com/ExtremsCorner/libogc-rice/commit/0aeb9c9ae13d296e63daf18381837825d0916426