### PR TITLE
general: Amend prototypes for functions with empty argument lists

### DIFF
--- a/gc/network.h
+++ b/gc/network.h
@@ -253,12 +253,12 @@ s32 net_init();
 typedef s32 (*netcallback)(s32 result, void *usrdata);
 s32 net_init_async(netcallback cb, void *usrdata);
 s32 net_get_status(void);
-void net_wc24cleanup();
+void net_wc24cleanup(void);
 #endif
 s32 net_get_mac_address(void *mac_buf);
-void net_deinit();
+void net_deinit(void);
 
-u32 net_gethostip();
+u32 net_gethostip(void);
 s32 net_socket(u32 domain,u32 type,u32 protocol);
 s32 net_bind(s32 s,struct sockaddr *name,socklen_t namelen);
 s32 net_listen(s32 s,u32 backlog);

--- a/gc/ogc/aram.h
+++ b/gc/ogc/aram.h
@@ -95,12 +95,12 @@ ARCallback AR_RegisterCallback(ARCallback callback);
 
 
 /*! 
- * \fn u32 AR_GetDMAStatus()
+ * \fn u32 AR_GetDMAStatus(void)
  * \brief Get current status of DMA
  *
  * \return zero if DMA is idle, non-zero if a DMA is in progress
  */
-u32 AR_GetDMAStatus();
+u32 AR_GetDMAStatus(void);
 
 
 /*! 
@@ -203,51 +203,51 @@ void AR_Clear(u32 flag);
 
 
 /*! 
- * \fn BOOL AR_CheckInit()
+ * \fn BOOL AR_CheckInit(void)
  * \brief Get the ARAM subsystem initialization flag
  *
  * \return TRUE if the ARAM subsystem has been initialized(via AR_Init())<br>
  *         FALSE if the ARAM subsystem has not been initialized, or has been reset(via AR_Reset())
  */
-BOOL AR_CheckInit();
+BOOL AR_CheckInit(void);
 
 
 /*!
- * \fn void AR_Reset()
+ * \fn void AR_Reset(void)
  * \brief Clears the ARAM subsystem initialization flag.
  *
  *        Calling AR_Init() after this function will cause a "real" initialization of ARAM
  *
  * \return none
  */
-void AR_Reset();
+void AR_Reset(void);
 
 
 /*! 
- * \fn u32 AR_GetSize()
+ * \fn u32 AR_GetSize(void)
  * \brief Get the total size - in bytes - of ARAM as calculated during AR_Init()
  *
  * \return size of the specified ARAM block
  */
-u32 AR_GetSize();
+u32 AR_GetSize(void);
 
 
 /*! 
- * \fn u32 AR_GetBaseAddress()
+ * \fn u32 AR_GetBaseAddress(void)
  * \brief Get the baseaddress of ARAM memory
  *
  * \return ARAM memory baseaddress
  */
-u32 AR_GetBaseAddress();
+u32 AR_GetBaseAddress(void);
 
 
 /*! 
- * \fn u32 AR_GetInternalSize()
+ * \fn u32 AR_GetInternalSize(void)
  * \brief Get the size of the internal ARAM memory
  *
  * \return ARAM internal memory size
  */
-u32 AR_GetInternalSize();
+u32 AR_GetInternalSize(void);
 
 
 /*! 

--- a/gc/ogc/arqueue.h
+++ b/gc/ogc/arqueue.h
@@ -64,8 +64,8 @@ struct _arq_request {
 	ARQCallback callback;
 };
 
-void ARQ_Init();
-void ARQ_Reset();
+void ARQ_Init(void);
+void ARQ_Reset(void);
 
 
 /*!
@@ -104,8 +104,8 @@ void ARQ_PostRequest(ARQRequest *req,u32 owner,u32 dir,u32 prio,u32 aram_addr,u3
 void ARQ_PostRequestAsync(ARQRequest *req,u32 owner,u32 dir,u32 prio,u32 aram_addr,u32 mram_addr,u32 len,ARQCallback cb);
 void ARQ_RemoveRequest(ARQRequest *req);
 void ARQ_SetChunkSize(u32 size);
-u32 ARQ_GetChunkSize();
-void ARQ_FlushQueue();
+u32 ARQ_GetChunkSize(void);
+void ARQ_FlushQueue(void);
 u32 ARQ_RemoveOwnerRequest(u32 owner);
 
 #ifdef __cplusplus

--- a/gc/ogc/audio.h
+++ b/gc/ogc/audio.h
@@ -122,12 +122,12 @@ void AUDIO_SetStreamVolLeft(u8 vol);
 
 
 /*! 
- * \fn u8 AUDIO_GetStreamVolLeft()
+ * \fn u8 AUDIO_GetStreamVolLeft(void)
  * \brief Get streaming volume of the left channel.
  *
  * \return level of volume.
  */
-u8 AUDIO_GetStreamVolLeft();
+u8 AUDIO_GetStreamVolLeft(void);
 
 
 /*! 
@@ -142,12 +142,12 @@ void AUDIO_SetStreamVolRight(u8 vol);
 
 
 /*! 
- * \fn u8 AUDIO_GetStreamVolRight()
+ * \fn u8 AUDIO_GetStreamVolRight(void)
  * \brief Get streaming volume of the right channel.
  *
  * \return level of volume.
  */
-u8 AUDIO_GetStreamVolRight();
+u8 AUDIO_GetStreamVolRight(void);
 
 
 /*! 
@@ -162,12 +162,12 @@ void AUDIO_SetStreamSampleRate(u32 rate);
 
 
 /*! 
- * \fn u32 AUDIO_GetStreamSampleRate()
+ * \fn u32 AUDIO_GetStreamSampleRate(void)
  * \brief Get streaming sample rate
  *
  * \return \ref ai_sample_rates "sample rate"
  */
-u32 AUDIO_GetStreamSampleRate();
+u32 AUDIO_GetStreamSampleRate(void);
 
 
 /*! 
@@ -197,16 +197,16 @@ void AUDIO_InitDMA(u32 startaddr,u32 len);
 
 
 /*! 
- * \fn u16 AUDIO_GetDMAEnableFlag()
+ * \fn u16 AUDIO_GetDMAEnableFlag(void)
  * \brief Get the audio DMA flag
  *
  * \return state of the current DMA operation.
  */
-u16 AUDIO_GetDMAEnableFlag();
+u16 AUDIO_GetDMAEnableFlag(void);
 
 
 /*! 
- * \fn void AUDIO_StartDMA()
+ * \fn void AUDIO_StartDMA(void)
  * \brief Start the audio DMA operation.
  *
  *        Starts to transfer the data from main memory to the audio interface thru DMA.<br>
@@ -214,43 +214,43 @@ u16 AUDIO_GetDMAEnableFlag();
  *
  * \return none
  */
-void AUDIO_StartDMA();
+void AUDIO_StartDMA(void);
 
 
 /*! 
- * \fn void AUDIO_StopDMA()
+ * \fn void AUDIO_StopDMA(void)
  * \brief Stop the previously started audio DMA operation.
  *
  * \return none
  */
-void AUDIO_StopDMA();
+void AUDIO_StopDMA(void);
 
 
 /*!
- * \fn u32 AUDIO_GetDMABytesLeft()
+ * \fn u32 AUDIO_GetDMABytesLeft(void)
  * \brief Get the count of bytes, left to play, from the audio DMA interface
  *
  * \return count of bytes left to play.
  */
-u32 AUDIO_GetDMABytesLeft();
+u32 AUDIO_GetDMABytesLeft(void);
 
 
 /*! 
- * \fn u32 AUDIO_GetDMALength()
+ * \fn u32 AUDIO_GetDMALength(void)
  * \brief Get the DMA transfer length configured in the audio DMA interface.
  * 
  * \return length of data loaded into the audio DMA interface.
  */
-u32 AUDIO_GetDMALength();
+u32 AUDIO_GetDMALength(void);
 
 
 /*! 
- * \fn u32 AUDIO_GetDMAStartAddr()
+ * \fn u32 AUDIO_GetDMAStartAddr(void)
  * \brief Get the main memory address for the DMA operation.
  *
  * \return start address of mainmemory loaded into the audio DMA interface.
  */
-u32 AUDIO_GetDMAStartAddr();
+u32 AUDIO_GetDMAStartAddr(void);
 
 
 /*! 
@@ -265,12 +265,12 @@ void AUDIO_SetStreamTrigger(u32 cnt);
 
 
 /*! 
- * \fn void AUDIO_ResetStreamSampleCnt()
+ * \fn void AUDIO_ResetStreamSampleCnt(void)
  * \brief Reset the stream sample count register.
  *
  * \return none
  */
-void AUDIO_ResetStreamSampleCnt();
+void AUDIO_ResetStreamSampleCnt(void);
 
 
 /*! 
@@ -285,12 +285,12 @@ void AUDIO_SetDSPSampleRate(u8 rate);
 
 
 /*! 
- * \fn u32 AUDIO_GetDSPSampleRate()
+ * \fn u32 AUDIO_GetDSPSampleRate(void)
  * \brief Get the sampling rate for the DSP interface
  *
  * \return DSP sampling rate (AI_SAMPLERATE_32KHZ,AI_SAMPLERATE_48KHZ)
  */
-u32 AUDIO_GetDSPSampleRate();
+u32 AUDIO_GetDSPSampleRate(void);
 
 
 /*! 
@@ -305,12 +305,12 @@ void AUDIO_SetStreamPlayState(u32 state);
 
 
 /*! 
- * \fn u32 AUDIO_GetStreamPlayState()
+ * \fn u32 AUDIO_GetStreamPlayState(void)
  * \brief Get the play state from the streaming audio interface
  *
  * \return playstate (AI_STREAM_STOP,AI_STREAM_START)
  */
-u32 AUDIO_GetStreamPlayState();
+u32 AUDIO_GetStreamPlayState(void);
 
 #ifdef __cplusplus
    }

--- a/gc/ogc/cache.h
+++ b/gc/ogc/cache.h
@@ -49,25 +49,25 @@ distribution.
 
 
 /*!
- * \fn void DCEnable()
+ * \fn void DCEnable(void)
  * \brief Enable L1 d-cache
  *
  * \return none
  */
-void DCEnable();
+void DCEnable(void);
 
 
 /*!
- * \fn void DCDisable()
+ * \fn void DCDisable(void)
  * \brief Disable L1 d-cache
  *
  * \return none
  */
-void DCDisable();
+void DCDisable(void);
 
 
 /*!
- * \fn void DCFreeze()
+ * \fn void DCFreeze(void)
  * \brief Current contents of the L1 d-cache are locked down and will not be cast out.
  *
  *        Hits are still serviced, but misses go straight to L2 or 60x bus.  Most cache operations, such as DCFlushRange(), will still execute regardless of whether the cache is frozen.<br>
@@ -75,11 +75,11 @@ void DCDisable();
  *
  * \return none
  */
-void DCFreeze();
+void DCFreeze(void);
 
 
 /*!
- * \fn void DCUnfreeze()
+ * \fn void DCUnfreeze(void)
  * \brief Undoes actions of DCFreeze().
  *
  *        Old cache blocks will now be cast out on subsequent L1 misses.<br>
@@ -87,11 +87,11 @@ void DCFreeze();
  *
  * \return none
  */
-void DCUnfreeze();
+void DCUnfreeze(void);
 
 
 /*!
- * \fn void DCFlashInvalidate()
+ * \fn void DCFlashInvalidate(void)
  * \brief Invalidate L1 d-cache.
  *
  *        An invalidate operation is issued that marks the state of each data cache block as invalid without writing back modified cache blocks to memory.<br>
@@ -99,7 +99,7 @@ void DCUnfreeze();
  *
  * \return none
  */
-void DCFlashInvalidate();
+void DCFlashInvalidate(void);
 
 
 /*!
@@ -198,18 +198,18 @@ void DCTouchRange(void *startaddress,u32 len);
 
 
 /*!
- * \fn void ICSync()
+ * \fn void ICSync(void)
  * \brief Performs an instruction cache synchronization.
  *
  *        This ensures that all instructions preceding this instruction have completed before this instruction completes.
  *
  * \return none
  */
-void ICSync();
+void ICSync(void);
 
 
 /*!
- * \fn void ICFlashInvalidate()
+ * \fn void ICFlashInvalidate(void)
  * \brief Invalidate the L1 i-cache.
  *
  *        An invalidate operation is issued that marks the state of each instruction cache block as invalid without writing back modified cache blocks to memory.<br>
@@ -217,29 +217,29 @@ void ICSync();
  *
  * \return none
  */
-void ICFlashInvalidate();
+void ICFlashInvalidate(void);
 
 
 /*!
- * \fn void ICEnable()
+ * \fn void ICEnable(void)
  * \brief Enable L1 i-cache
  *
  * \return none
  */
-void ICEnable();
+void ICEnable(void);
 
 
 /*!
- * \fn void ICDisable()
+ * \fn void ICDisable(void)
  * \brief Disable L1 i-cache
  *
  * \return none
  */
-void ICDisable();
+void ICDisable(void);
 
 
 /*!
- * \fn void ICFreeze()
+ * \fn void ICFreeze(void)
  * \brief Current contents of the L1 i-cache are locked down and will not be cast out.
  *
  *        Hits are still serviced, but misses go straight to L2 or 60x bus.<br>
@@ -247,11 +247,11 @@ void ICDisable();
  *
  * \return none
  */
-void ICFreeze();
+void ICFreeze(void);
 
 
 /*!
- * \fn void ICUnfreeze()
+ * \fn void ICUnfreeze(void)
  * \brief Undoes actions of ICFreeze().
  *
  *        Old cache blocks will now be cast out on subsequent L1 misses.<br>
@@ -259,7 +259,7 @@ void ICFreeze();
  *
  * \return none
  */
-void ICUnfreeze();
+void ICUnfreeze(void);
 
 
 /*!
@@ -289,7 +289,7 @@ void ICBlockInvalidate(void *startaddress);
 void ICInvalidateRange(void *startaddress,u32 len);
 
 /*!
- * \fn void L2Enhance()
+ * \fn void L2Enhance(void)
  * \brief Turn on extra L2 cache features
  *
  *        Sets the following bits in the HID4 register which affect the L2 cache:
@@ -301,18 +301,18 @@ void ICInvalidateRange(void *startaddress,u32 len);
  * \return none
  */
 #ifdef HW_RVL
-void L2Enhance();
+void L2Enhance(void);
 #endif
 
-void LCEnable();
-void LCDisable();
+void LCEnable(void);
+void LCDisable(void);
 void LCLoadBlocks(void *,void *,u32);
 void LCStoreBlocks(void *,void *,u32);
 u32 LCLoadData(void *,void *,u32);
 u32 LCStoreData(void *,void *,u32);
-u32 LCQueueLength();
+u32 LCQueueLength(void);
 u32 LCQueueWait(u32);
-void LCFlushQueue();
+void LCFlushQueue(void);
 void LCAlloc(void *,u32);
 void LCAllocNoInvalidate(void *,u32);
 void LCAllocOneTag(BOOL,void *);

--- a/gc/ogc/cast.h
+++ b/gc/ogc/cast.h
@@ -30,7 +30,7 @@ extern "C" {
 #define __set_gqr(_reg,_val)	asm volatile("mtspr %0,%1" : : "i"(_reg), "b"(_val))
 
 // does a default init
-static inline void CAST_Init()
+static inline void CAST_Init(void)
 {
 	__asm__ __volatile__ (
 		"li		3,0x0004\n\

--- a/gc/ogc/dsp.h
+++ b/gc/ogc/dsp.h
@@ -138,44 +138,44 @@ struct _dsp_task {
 };
 
 
-/*! \fn void DSP_Init()
+/*! \fn void DSP_Init(void)
 \brief Initialize DSP subsystem.
 
 \return none
 */
-void DSP_Init();
+void DSP_Init(void);
 
 
-/*! \fn u32 DSP_CheckMailTo()
+/*! \fn u32 DSP_CheckMailTo(void)
 \brief Check if mail was sent to DSP
 
 \return 1: mail sent, 0: mail on route
 */
-u32 DSP_CheckMailTo();
+u32 DSP_CheckMailTo(void);
 
 
-/*! \fn u32 DSP_CheckMailFrom()
+/*! \fn u32 DSP_CheckMailFrom(void)
 \brief Check for mail from DSP
 
 \return 1: has mail, 0: no mail
 */
-u32 DSP_CheckMailFrom();
+u32 DSP_CheckMailFrom(void);
 
 
-/*! \fn u32 DSP_ReadMailFrom()
+/*! \fn u32 DSP_ReadMailFrom(void)
 \brief Read mail from DSP
 
 \return mail value received
 */
-u32 DSP_ReadMailFrom();
+u32 DSP_ReadMailFrom(void);
 
 
-/*! \fn void DSP_AssertInt()
+/*! \fn void DSP_AssertInt(void)
 \brief Asserts the processor interface interrupt
 
 \return none
 */
-void DSP_AssertInt();
+void DSP_AssertInt(void);
 
 
 /*! \fn void DSP_SendMailTo(u32 mail)
@@ -187,12 +187,12 @@ void DSP_AssertInt();
 void DSP_SendMailTo(u32 mail);
 
 
-/*! \fn u32 DSP_ReadCPUtoDSP()
+/*! \fn u32 DSP_ReadCPUtoDSP(void)
 \brief Read back CPU->DSP mailbox
 
 \return mail value received
 */
-u32 DSP_ReadCPUtoDSP();
+u32 DSP_ReadCPUtoDSP(void);
 
 
 /*! \fn dsptask_t* DSP_AddTask(dsptask_t *task)
@@ -207,11 +207,11 @@ dsptask_t* DSP_AssertTask(dsptask_t *task);
 
 void DSP_CancelTask(dsptask_t *task);
 
-void DSP_Reset();
+void DSP_Reset(void);
 
-void DSP_Halt();
+void DSP_Halt(void);
 
-void DSP_Unhalt();
+void DSP_Unhalt(void);
 
 /*! \fn DSPCallback DSP_RegisterCallback(DSPCallback usr_cb)
 \brief Register an user's interrupt callback. This may be used to handle DSP interrupts on its own. By default a system default callback is installed on DSP_Init().

--- a/gc/ogc/dvd.h
+++ b/gc/ogc/dvd.h
@@ -226,15 +226,15 @@ struct _dvdfileinfo {
 
 
 /*! 
- * \fn void DVD_Init()
+ * \fn void DVD_Init(void)
  * \brief Initializes the DVD subsystem
  *
  *        You must call this function before calling any other DVD function
  *
  * \return none
  */
-void DVD_Init();
-void DVD_Pause();
+void DVD_Init(void);
+void DVD_Pause(void);
 
 
 /*! 
@@ -249,15 +249,15 @@ void DVD_Reset(u32 reset_mode);
 
 
 /*! 
- * \fn s32 DVD_Mount()
+ * \fn s32 DVD_Mount(void)
  * \brief Mounts the DVD drive.
  *
  *        This is a synchronous version of DVD_MountAsync().
  *
  * \return none
  */
-s32 DVD_Mount();
-s32 DVD_GetDriveStatus();
+s32 DVD_Mount(void);
+s32 DVD_GetDriveStatus(void);
 
 
 /*! 
@@ -353,8 +353,8 @@ s32 DVD_StopStreamAtEndAsync(dvdcmdblk *block,dvdcbcallback cb);
 s32 DVD_StopStreamAtEnd(dvdcmdblk *block);
 s32 DVD_ReadDiskID(dvdcmdblk *block,dvddiskid *id,dvdcbcallback cb);
 u32 DVD_SetAutoInvalidation(u32 auto_inv);
-dvddiskid* DVD_GetCurrentDiskID();
-dvddrvinfo* DVD_GetDriveInfo();
+dvddiskid* DVD_GetCurrentDiskID(void);
+dvddrvinfo* DVD_GetDriveInfo(void);
 
 #define DVD_SetUserData(block, data) ((block)->usrdata = (data))
 #define DVD_GetUserData(block)       ((block)->usrdata)

--- a/gc/ogc/exi.h
+++ b/gc/ogc/exi.h
@@ -301,12 +301,12 @@ s32 EXI_Attach(s32 nChn,EXICallback ext_cb);
 s32 EXI_Detach(s32 nChn);
 
 
-/*! \fn void EXI_ProbeReset()
+/*! \fn void EXI_ProbeReset(void)
 \brief Resets certain internal flags and counters and performs a probe on all 3 channels.
 
 \return nothing
 */
-void EXI_ProbeReset();
+void EXI_ProbeReset(void);
 
 
 /*! \fn EXICallback EXI_RegisterEXICallback(s32 nChn,EXICallback exi_cb)

--- a/gc/ogc/gx.h
+++ b/gc/ogc/gx.h
@@ -1590,7 +1590,7 @@ GXDrawDoneCallback GX_SetDrawDoneCallback(GXDrawDoneCallback cb);
 GXBreakPtCallback GX_SetBreakPtCallback(GXBreakPtCallback cb);
 
 /*!
- * \fn void GX_AbortFrame()
+ * \fn void GX_AbortFrame(void)
  * \brief Aborts the current frame.
  *
  * \details This command will reset the entire graphics pipeline, including any commands in the graphics FIFO.
@@ -1601,17 +1601,17 @@ GXBreakPtCallback GX_SetBreakPtCallback(GXBreakPtCallback cb);
  *
  * \return none
  */
-void GX_AbortFrame();
+void GX_AbortFrame(void);
 
 /*!
- * \fn void GX_Flush()
+ * \fn void GX_Flush(void)
  * \brief Flushes all commands to the GP.
  *
  * \details Specifically, it flushes the write-gather FIFO in the CPU to make sure that all commands are sent to the GP.
  *
  * \return none
  */
-void GX_Flush();
+void GX_Flush(void);
 
 /*!
  * \fn void GX_SetMisc(u32 token,u32 value)
@@ -1625,7 +1625,7 @@ void GX_Flush();
 void GX_SetMisc(u32 token,u32 value);
 
 /*!
- * \fn void GX_SetDrawDone()
+ * \fn void GX_SetDrawDone(void)
  * \brief Sends a DrawDone command to the GP.
  *
  * \details When all previous commands have been processed and the pipeline is empty, a <i>DrawDone</i> status bit will be set,
@@ -1638,10 +1638,10 @@ void GX_SetMisc(u32 token,u32 value);
  *
  * \return none
  */
-void GX_SetDrawDone();
+void GX_SetDrawDone(void);
 
 /*!
- * \fn void GX_WaitDrawDone()
+ * \fn void GX_WaitDrawDone(void)
  * \brief Stalls until <i>DrawDone</i> is encountered by the GP.
  *
  * \details It means all graphics commands sent before this DrawDone command have executed and the last pixel has been written to
@@ -1653,15 +1653,15 @@ void GX_SetDrawDone();
  *
  * \return none
  */
-void GX_WaitDrawDone();
+void GX_WaitDrawDone(void);
 
 /*!
- * \fn u16 GX_GetDrawSync()
+ * \fn u16 GX_GetDrawSync(void)
  * \brief Returns the value of the token register, which is written using the GX_SetDrawSync() function.
  *
  * \return the value of the token register.
  */
-u16 GX_GetDrawSync();
+u16 GX_GetDrawSync(void);
 
 /*!
  * \fn void GX_SetDrawSync(u16 token)
@@ -1692,7 +1692,7 @@ void GX_SetDrawSync(u16 token);
 GXDrawSyncCallback GX_SetDrawSyncCallback(GXDrawSyncCallback cb);
 
 /*!
- * \fn void GX_DisableBreakPt()
+ * \fn void GX_DisableBreakPt(void)
  * \brief Allows reads from the FIFO currently attached to the Graphics Processor (GP) to resume.
  *
  * \details See GX_EnableBreakPt() for an explanation of the FIFO break point feature.
@@ -1701,7 +1701,7 @@ GXDrawSyncCallback GX_SetDrawSyncCallback(GXDrawSyncCallback cb);
  *
  * \return none
  */
-void GX_DisableBreakPt();
+void GX_DisableBreakPt(void);
 
 /*!
  * \fn void GX_EnableBreakPt(void *break_pt)
@@ -1729,17 +1729,17 @@ void GX_DisableBreakPt();
 void GX_EnableBreakPt(void *break_pt);
 
 /*!
- * \fn void GX_DrawDone()
+ * \fn void GX_DrawDone(void)
  * \brief Sends a DrawDone command to the GP and stalls until its subsequent execution.
  *
  * \note This function is equivalent to calling GX_SetDrawDone() then GX_WaitDrawDone().
  *
  * \return none
  */
-void GX_DrawDone();
+void GX_DrawDone(void);
 
 /*!
- * \fn void GX_TexModeSync()
+ * \fn void GX_TexModeSync(void)
  * \brief Inserts a synchronization command into the graphics FIFO. When the Graphics Processor sees this command, it will
  * allow the texture pipeline to flush before continuing.
  *
@@ -1751,10 +1751,10 @@ void GX_DrawDone();
  *
  * \return none
  */
-void GX_TexModeSync();
+void GX_TexModeSync(void);
 
 /*!
- * \fn void GX_InvVtxCache();
+ * \fn void GX_InvVtxCache(void)
  * \brief Invalidates the vertex cache.
  *
  * \details Specifically, this functions invalidates the vertex cache tags. This function should be used whenever you relocate or modify
@@ -1767,17 +1767,17 @@ void GX_TexModeSync();
  *
  * \return none
  */
-void GX_InvVtxCache();
+void GX_InvVtxCache(void);
 
 /*!
- * \fn void GX_ClearVtxDesc()
+ * \fn void GX_ClearVtxDesc(void)
  * \brief Clears all vertex attributes of the current vertex descriptor to GX_NONE.
  *
  * \note The same functionality can be obtained using GX_SetVtxDescv(), however using GX_ClearVtxDesc() is much more efficient.
  *
  * \return none
  */
-void GX_ClearVtxDesc();
+void GX_ClearVtxDesc(void);
 
 /*!
  * \fn void GX_LoadProjectionMtx(Mtx44 mt,u8 type)
@@ -2012,7 +2012,7 @@ void GX_SetVtxDescv(GXVtxDesc *attr_list);
 void GX_GetVtxDescv(GXVtxDesc *attr_list);
 
 /*!
- * \fn u32 GX_EndDispList()
+ * \fn u32 GX_EndDispList(void)
  * \brief Ends a display list and resumes writing graphics commands to the CPU FIFO.
  *
  * \details This function returns the size of the display list written to the display list buffer since GX_BeginDispList() was called. If
@@ -2034,7 +2034,7 @@ void GX_GetVtxDescv(GXVtxDesc *attr_list);
  * \bug Specifying a display list buffer size for GX_BeginDispList() the exact size that the display list will be (after padding) will cause
  * this function to return a very large (and very incorrect) value.
  */
-u32 GX_EndDispList();
+u32 GX_EndDispList(void);
 
 /*!
  * \fn void GX_Begin(u8 primitve,u8 vtxfmt,u16 vtxcnt)
@@ -2109,12 +2109,12 @@ void GX_BeginDispList(void *list,u32 size);
 void GX_CallDispList(void *list,u32 nbytes);
 
 /*!
- * \fn static inline void GX_End()
+ * \fn static inline void GX_End(void)
  * \brief Used to end the drawing of a graphics primitive. This does nothing in libogc.
  *
  * \return none
  */
-static inline void GX_End()
+static inline void GX_End(void)
 {
 }
 
@@ -3732,7 +3732,7 @@ void GX_SetTexCopyDst(u16 wd,u16 ht,u32 fmt,u8 mipmap);
 void GX_CopyTex(void *dest,u8 clear);
 
 /*!
- * \fn void GX_PixModeSync()
+ * \fn void GX_PixModeSync(void)
  * \brief Causes the GPU to wait for the pipe to flush.
  *
  * \details This function inserts a synchronization command into the graphics FIFO. When the GPU sees this command it will allow the rest of the pipe to
@@ -3743,17 +3743,17 @@ void GX_CopyTex(void *dest,u8 clear);
  *
  * \return none
  */
-void GX_PixModeSync();
+void GX_PixModeSync(void);
 
 /*!
- * \fn void GX_ClearBoundingBox()
+ * \fn void GX_ClearBoundingBox(void)
  * \brief Clears the bounding box values before a new image is drawn.
  *
  * \details The graphics hardware keeps track of a bounding box of pixel coordinates that are drawn in the Embedded Frame Buffer (EFB).
  *
  * \return none
  */
-void GX_ClearBoundingBox();
+void GX_ClearBoundingBox(void);
 
 /*!
  * \fn GX_PokeAlphaMode(u8 func,u8 threshold)
@@ -4092,7 +4092,7 @@ void GX_GetTexObjAll(GXTexObj* obj, void** image_ptr, u16* width, u16* height, u
 u32 GX_GetTexBufferSize(u16 wd,u16 ht,u32 fmt,u8 mipmap,u8 maxlod);
 
 /*!
- * \fn void GX_InvalidateTexAll()
+ * \fn void GX_InvalidateTexAll(void)
  * \brief Invalidates the current caches of the Texture Memory (TMEM).
  *
  * \details It takes about 512 GP clocks to invalidate all the texture caches.
@@ -4101,7 +4101,7 @@ u32 GX_GetTexBufferSize(u16 wd,u16 ht,u32 fmt,u8 mipmap,u8 maxlod);
  *
  * \return none
  */
-void GX_InvalidateTexAll();
+void GX_InvalidateTexAll(void);
 
 /*!
  * \fn void GX_InvalidateTexRegion(GXTexRegion *region)
@@ -4886,12 +4886,12 @@ void GX_InitSpecularDir(GXLightObj *lit_obj,f32 nx,f32 ny,f32 nz);
  */
 void GX_InitLightSpot(GXLightObj *lit_obj,f32 cut_off,u8 spotfn);
 
-u32 GX_ReadClksPerVtx();
-u32 GX_GetOverflowCount();
-u32 GX_ResetOverflowCount();
+u32 GX_ReadClksPerVtx(void);
+u32 GX_GetOverflowCount(void);
+u32 GX_ResetOverflowCount(void);
 
 /*!
- * \fn lwp_t GX_GetCurrentGXThread()
+ * \fn lwp_t GX_GetCurrentGXThread(void)
  * \brief Returns the current GX thread.
  *
  * \details The current GX thread should be the thread that is currently responsible for generating graphics data. By default,
@@ -4903,10 +4903,10 @@ u32 GX_ResetOverflowCount();
  *
  * \return the current GX thread
  */
-lwp_t GX_GetCurrentGXThread();
+lwp_t GX_GetCurrentGXThread(void);
 
 /*!
- * \fn lwp_t GX_SetCurrentGXThread()
+ * \fn lwp_t GX_SetCurrentGXThread(void)
  * \brief Sets the current GX thread to the calling thread.
  *
  * \details The new thread should be the thread that will be responsible for generating graphics data. By default, the GX thread is
@@ -4921,10 +4921,10 @@ lwp_t GX_GetCurrentGXThread();
  *
  * \return the previous GX thread ID
  */
-lwp_t GX_SetCurrentGXThread();
+lwp_t GX_SetCurrentGXThread(void);
 
 /*!
- * \fn void GX_RestoreWriteGatherPipe()
+ * \fn void GX_RestoreWriteGatherPipe(void)
  * \brief Restores the write-gather pipe.
  *
  * \details The CPU fifo that was attached at the time GX_RedirectWriteGatherPipe() was called will be re-attached. If there is data pending
@@ -4935,7 +4935,7 @@ lwp_t GX_SetCurrentGXThread();
  *
  * \return none
  */
-void GX_RestoreWriteGatherPipe();
+void GX_RestoreWriteGatherPipe(void);
 
 /*!
  * \fn void GX_SetGPMetric(u32 perf0,u32 perf1)
@@ -4965,7 +4965,7 @@ void GX_RestoreWriteGatherPipe();
 void GX_SetGPMetric(u32 perf0,u32 perf1);
 
 /*!
- * \fn void GX_ClearGPMetric()
+ * \fn void GX_ClearGPMetric(void)
  * \brief Clears the two virtual GP performance counters to zero.
  *
  * \note The counter's function is set using GX_SetGPMetric(); the counter's value is read using GX_ReadGPMetric(). Consult these for more details.
@@ -4974,17 +4974,17 @@ void GX_SetGPMetric(u32 perf0,u32 perf1);
  *
  * \return none
  */
-void GX_ClearGPMetric();
+void GX_ClearGPMetric(void);
 
 /*!
- * \fn void GX_InitXfRasMetric()
+ * \fn void GX_InitXfRasMetric(void)
  * \brief Initialize the transformation unit (XF) rasterizer unit (RAS) to take performance measurements.
  *
  * \warning This function should be avoided; use the GP performance metric functions instead.
  *
  * \return none
  */
-void GX_InitXfRasMetric();
+void GX_InitXfRasMetric(void);
 
 /*!
  * \fn void GX_ReadXfRasMetric(u32 *xfwaitin,u32 *xfwaitout,u32 *rasbusy,u32 *clks)
@@ -5004,7 +5004,7 @@ void GX_InitXfRasMetric();
 void GX_ReadXfRasMetric(u32 *xfwaitin,u32 *xfwaitout,u32 *rasbusy,u32 *clks);
 
 /*!
- * \fn void GX_ClearVCacheMetric()
+ * \fn void GX_ClearVCacheMetric(void)
  * \brief Clears the Vertex Cache performance counter.
  *
  * \details This function clears the performance counter by sending a special clear token via the Graphics FIFO.
@@ -5013,7 +5013,7 @@ void GX_ReadXfRasMetric(u32 *xfwaitin,u32 *xfwaitout,u32 *rasbusy,u32 *clks);
  *
  * \return none
  */
-void GX_ClearVCacheMetric();
+void GX_ClearVCacheMetric(void);
 
 /*!
  * \fn void GX_ReadVCacheMetric(u32 *check,u32 *miss,u32 *stall)

--- a/gc/ogc/ios.h
+++ b/gc/ogc/ios.h
@@ -51,10 +51,10 @@ s32 __IOS_LoadStartupIOS(void);
 s32 __IOS_LaunchNewIOS(int version);
 s32 IOS_GetPreferredVersion(void);
 s32 IOS_ReloadIOS(int version);
-s32 IOS_GetVersion();
-s32 IOS_GetRevision();
-s32 IOS_GetRevisionMajor();
-s32 IOS_GetRevisionMinor();
+s32 IOS_GetVersion(void);
+s32 IOS_GetRevision(void);
+s32 IOS_GetRevisionMajor(void);
+s32 IOS_GetRevisionMinor(void);
 
 #ifdef __cplusplus
    }

--- a/gc/ogc/ipc.h
+++ b/gc/ogc/ipc.h
@@ -67,8 +67,8 @@ s32 iosCreateHeap(s32 size);
 void* iosAlloc(s32 hid,s32 size);
 void iosFree(s32 hid,void *ptr);
 
-void* IPC_GetBufferLo();
-void* IPC_GetBufferHi();
+void* IPC_GetBufferLo(void);
+void* IPC_GetBufferHi(void);
 void IPC_SetBufferLo(void *bufferlo);
 void IPC_SetBufferHi(void *bufferhi);
 

--- a/gc/ogc/isfs.h
+++ b/gc/ogc/isfs.h
@@ -27,8 +27,8 @@ typedef struct _fstats
 
 typedef s32 (*isfscallback)(s32 result,void *usrdata);
 
-s32 ISFS_Initialize();
-s32 ISFS_Deinitialize();
+s32 ISFS_Initialize(void);
+s32 ISFS_Deinitialize(void);
 
 s32 ISFS_Open(const char *filepath,u8 mode);
 s32 ISFS_OpenAsync(const char *filepath,u8 mode,isfscallback cb,void *usrdata);

--- a/gc/ogc/lwp.h
+++ b/gc/ogc/lwp.h
@@ -108,12 +108,12 @@ s32 LWP_ResumeThread(lwp_t thethread);
 BOOL LWP_ThreadIsSuspended(lwp_t thethread);
 
 
-/*! \fn lwp_t LWP_GetSelf()
+/*! \fn lwp_t LWP_GetSelf(void)
 \brief Return the handle to the current thread.
 
 \return thread context handle
 */
-lwp_t LWP_GetSelf();
+lwp_t LWP_GetSelf(void);
 
 
 /*! \fn void LWP_SetThreadPriority(lwp_t thethread,u32 prio)
@@ -126,12 +126,12 @@ lwp_t LWP_GetSelf();
 void LWP_SetThreadPriority(lwp_t thethread,u32 prio);
 
 
-/*! \fn void LWP_YieldThread()
+/*! \fn void LWP_YieldThread(void)
 \brief Yield the current thread to another one with higher priority or if not running at the same priority which state is runnable.
 
 \return none
 */
-void LWP_YieldThread();
+void LWP_YieldThread(void);
 
 
 /*! \fn void LWP_Reschedule(u32 prio)

--- a/gc/ogc/lwp_priority.h
+++ b/gc/ogc/lwp_priority.h
@@ -20,7 +20,7 @@ typedef struct _priocntrl {
 extern vu32 _prio_major_bitmap;
 extern u32 _prio_bitmap[];
 
-void __lwp_priority_init();
+void __lwp_priority_init(void);
 
 #ifdef LIBOGC_INTERNAL
 #include <libogc/lwp_priority.inl>

--- a/gc/ogc/lwp_watchdog.h
+++ b/gc/ogc/lwp_watchdog.h
@@ -68,8 +68,8 @@ extern u32 _wd_ticks_since_boot;
 
 extern lwp_queue _wd_ticks_queue;
 
-extern u32 gettick();
-extern u64 gettime();
+extern u32 gettick(void);
+extern u64 gettime(void);
 extern void settime(u64);
 
 u32 diff_sec(u64 start,u64 end);

--- a/gc/ogc/pad.h
+++ b/gc/ogc/pad.h
@@ -61,8 +61,8 @@ typedef void (*sampling_callback)(void);
 /*+----------------------------------------------------------------------------------------------+*/
 /*+----------------------------------------------------------------------------------------------+*/
 
-u32 PAD_Init();
-u32 PAD_Sync();
+u32 PAD_Init(void);
+u32 PAD_Sync(void);
 u32 PAD_Read(PADStatus *status);
 u32 PAD_Reset(u32 mask);
 u32 PAD_Recalibrate(u32 mask);
@@ -70,7 +70,7 @@ void PAD_Clamp(PADStatus *status);
 void PAD_ControlMotor(s32 chan,u32 cmd);
 void PAD_SetSpec(u32 spec);
 
-u32 PAD_ScanPads();
+u32 PAD_ScanPads(void);
 
 u16 PAD_ButtonsUp(int pad);
 u16 PAD_ButtonsDown(int pad);

--- a/gc/ogc/si.h
+++ b/gc/ogc/si.h
@@ -69,8 +69,8 @@
 typedef void (*SICallback)(s32,u32);
 typedef void (*RDSTHandler)(u32,void*);
 
-u32 SI_Sync();
-u32 SI_Busy();
+u32 SI_Sync(void);
+u32 SI_Busy(void);
 u32 SI_IsChanBusy(s32 chan);
 void SI_EnablePolling(u32 poll);
 void SI_DisablePolling(u32 poll);
@@ -78,12 +78,12 @@ void SI_SetCommand(s32 chan,u32 cmd);
 u32 SI_GetStatus(s32 chan);
 u32 SI_GetResponse(s32 chan,void *buf);
 u32 SI_GetResponseRaw(s32 chan);
-void SI_RefreshSamplingRate();
+void SI_RefreshSamplingRate(void);
 u32 SI_Transfer(s32 chan,void *out,u32 out_len,void *in,u32 in_len,SICallback cb,u32 us_delay);
 u32 SI_GetTypeAsync(s32 chan,SICallback cb);
 u32 SI_GetType(s32 chan);
 u32 SI_GetCommand(s32 chan);
-void SI_TransferCommands();
+void SI_TransferCommands(void);
 u32 SI_RegisterPollingHandler(RDSTHandler handler);
 u32 SI_UnregisterPollingHandler(RDSTHandler handler);
 u32 SI_EnablePollingInterrupt(s32 enable);

--- a/gc/ogc/stm.h
+++ b/gc/ogc/stm.h
@@ -49,12 +49,12 @@ distribution.
 
 typedef void (*stmcallback)(u32 event);
 
-s32 __STM_Init();
-s32 __STM_Close();
-s32 STM_ShutdownToStandby();
-s32 STM_ShutdownToIdle();
+s32 __STM_Init(void);
+s32 __STM_Close(void);
+s32 STM_ShutdownToStandby(void);
+s32 STM_ShutdownToIdle(void);
 s32 STM_SetLedMode(u32 mode);
-s32 STM_RebootSystem();
+s32 STM_RebootSystem(void);
 stmcallback STM_RegisterEventHandler(stmcallback newhandler);
 
 #ifdef __cplusplus

--- a/gc/ogc/system.h
+++ b/gc/ogc/system.h
@@ -219,8 +219,8 @@ struct _sys_fontheader {
     u8  c3;
 } ATTRIBUTE_PACKED;
 
-typedef void (*resetcallback)(void);
-typedef void (*powercallback)(void);
+typedef void (*resetcallback)();
+typedef void (*powercallback)();
 typedef s32 (*resetfunction)(s32 final);
 typedef struct _sys_resetinfo sys_resetinfo;
 
@@ -230,12 +230,12 @@ struct _sys_resetinfo {
 	u32 prio;
 };
 
-/*! \fn void SYS_Init()
+/*! \fn void SYS_Init(void)
 \deprecated Performs basic system initialization such as EXI init etc. This function is called from within the crt0 startup code.
 
 \return none
 */
-void SYS_Init();
+void SYS_Init(void);
 
 
 /*!
@@ -250,8 +250,8 @@ void* SYS_AllocateFramebuffer(GXRModeObj *rmode);
 
 void SYS_ProtectRange(u32 chan,void *addr,u32 bytes,u32 cntrl);
 void SYS_StartPMC(u32 mcr0val,u32 mcr1val);
-void SYS_DumpPMC();
-void SYS_StopPMC();
+void SYS_DumpPMC(void);
+void SYS_StopPMC(void);
 
 
 /*! \fn s32 SYS_CreateAlarm(syswd_t *thealarm)
@@ -306,7 +306,7 @@ s32 SYS_CancelAlarm(syswd_t thealarm);
 
 void SYS_SetWirelessID(u32 chan,u32 id);
 u32 SYS_GetWirelessID(u32 chan);
-u32 SYS_GetFontEncoding();
+u32 SYS_GetFontEncoding(void);
 u32 SYS_InitFont(sys_fontheader *font_data);
 void SYS_GetFontTexture(s32 c,void **image,s32 *xpos,s32 *ypos,s32 *width);
 void SYS_GetFontTexel(s32 c,void *image,s32 pos,s32 stride,s32 *width);
@@ -315,31 +315,31 @@ void SYS_RegisterResetFunc(sys_resetinfo *info);
 void SYS_UnregisterResetFunc(sys_resetinfo *info);
 void SYS_SwitchFiber(u32 arg0,u32 arg1,u32 arg2,u32 arg3,u32 pc,u32 newsp);
 
-void* SYS_GetArena1Lo();
+void* SYS_GetArena1Lo(void);
 void SYS_SetArena1Lo(void *newLo);
-void* SYS_GetArena1Hi();
+void* SYS_GetArena1Hi(void);
 void SYS_SetArena1Hi(void *newHi);
-u32 SYS_GetArena1Size();
+u32 SYS_GetArena1Size(void);
 
 resetcallback SYS_SetResetCallback(resetcallback cb);
 
-u32 SYS_ResetButtonDown();
+u32 SYS_ResetButtonDown(void);
 
 #if defined(HW_RVL)
-u32 SYS_GetHollywoodRevision();
-void* SYS_GetArena2Lo();
+u32 SYS_GetHollywoodRevision(void);
+void* SYS_GetArena2Lo(void);
 void SYS_SetArena2Lo(void *newLo);
-void* SYS_GetArena2Hi();
+void* SYS_GetArena2Hi(void);
 void SYS_SetArena2Hi(void *newHi);
-u32 SYS_GetArena2Size();
+u32 SYS_GetArena2Size(void);
 powercallback SYS_SetPowerCallback(powercallback cb);
 #endif
 
-/* \fn u64 SYS_Time()
+/* \fn u64 SYS_Time(void)
 \brief Returns the current time in ticks since 2000 (proper Dolphin/Wii time)
 \return ticks since 2000
 */
-u64 SYS_Time();
+u64 SYS_Time(void);
 
 void kprintf(const char *str, ...);
 

--- a/gc/ogc/usb.h
+++ b/gc/ogc/usb.h
@@ -178,8 +178,8 @@ typedef struct _usb_device_entry {
 
 typedef s32 (*usbcallback)(s32 result,void *usrdata);
 
-s32 USB_Initialize();
-s32 USB_Deinitialize();
+s32 USB_Initialize(void);
+s32 USB_Deinitialize(void);
 
 s32 USB_OpenDevice(s32 device_id,u16 vid,u16 pid,s32 *fd);
 s32 USB_CloseDevice(s32 *fd);

--- a/gc/ogc/usbstorage.h
+++ b/gc/ogc/usbstorage.h
@@ -62,7 +62,7 @@ typedef struct {
    size_t          data_length;
 } raw_device_command;
 
-s32 USBStorage_Initialize();
+s32 USBStorage_Initialize(void);
 
 s32 USBStorage_Open(usbstorage_handle *dev, s32 device_id, u16 vid, u16 pid);
 s32 USBStorage_Close(usbstorage_handle *dev);
@@ -71,7 +71,7 @@ s32 USBStorage_Reset(usbstorage_handle *dev);
 s32 USBStorage_GetMaxLUN(usbstorage_handle *dev);
 s32 USBStorage_MountLUN(usbstorage_handle *dev, u8 lun);
 s32 USBStorage_Suspend(usbstorage_handle *dev);
-s32 USBStorage_IsDVD();
+s32 USBStorage_IsDVD(void);
 s32 USBStorage_ioctl(int request, ...);
 
 s32 USBStorage_ReadCapacity(usbstorage_handle *dev, u8 lun, u32 *sector_size, u32 *n_sectors);

--- a/gc/ogc/video.h
+++ b/gc/ogc/video.h
@@ -55,26 +55,26 @@ typedef void (*VIRetraceCallback)(u32 retraceCnt);
 
 typedef void (*VIPositionCallback)(u32 posX,u32 posY);
 
-void* VIDEO_GetNextFramebuffer();
-void* VIDEO_GetCurrentFramebuffer();
+void* VIDEO_GetNextFramebuffer(void);
+void* VIDEO_GetCurrentFramebuffer(void);
 
 
 /*! 
- * \fn void VIDEO_Init()
+ * \fn void VIDEO_Init(void)
  * \brief Initializes the VIDEO subsystem. This call should be done in the early stages of your main()
  *
  * \return none
  */
-void VIDEO_Init();
+void VIDEO_Init(void);
 
 
 /*! 
- * \fn void VIDEO_Flush()
+ * \fn void VIDEO_Flush(void)
  * \brief Flush the shadow registers to the drivers video registers.
  *
  * \return none
  */
-void VIDEO_Flush();
+void VIDEO_Flush(void);
 
 
 /*!
@@ -89,30 +89,30 @@ void VIDEO_SetBlack(bool black);
 
 
 /*! 
- * \fn u32 VIDEO_GetNextField()
+ * \fn u32 VIDEO_GetNextField(void)
  * \brief Get the next field in DS mode.
  *
  * \return \ref vi_fielddef "field"
  */
-u32 VIDEO_GetNextField();
+u32 VIDEO_GetNextField(void);
 
 
 /*! 
- * \fn u32 VIDEO_GetCurrentLine()
+ * \fn u32 VIDEO_GetCurrentLine(void)
  * \brief Get current video line
  *
  * \return linenumber
  */
-u32 VIDEO_GetCurrentLine();
+u32 VIDEO_GetCurrentLine(void);
 
 
 /*! 
- * \fn u32 VIDEO_GetCurrentTvMode()
+ * \fn u32 VIDEO_GetCurrentTvMode(void)
  * \brief Get current configured TV mode
  *
  * \return \ref vi_standardtypedef "tvmode"
  */
-u32 VIDEO_GetCurrentTvMode();
+u32 VIDEO_GetCurrentTvMode(void);
 
 
 /*! 

--- a/gc/sdcard/card_buf.h
+++ b/gc/sdcard/card_buf.h
@@ -7,8 +7,8 @@
 	extern "C" {
 #endif
 
-void sdgecko_initBufferPool();
-u8*	sdgecko_allocBuffer();
+void sdgecko_initBufferPool(void);
+u8*	sdgecko_allocBuffer(void);
 void sdgecko_freeBuffer(u8 *buf);
 
 #ifdef __cplusplus

--- a/gc/sdcard/card_io.h
+++ b/gc/sdcard/card_io.h
@@ -28,7 +28,7 @@ extern u8 g_mCode[MAX_MI_NUM];
 extern u16 g_dCode[MAX_MI_NUM][MAX_DI_NUM];
 
 
-void sdgecko_initIODefault();
+void sdgecko_initIODefault(void);
 s32 sdgecko_initIO(s32 drv_no);
 s32 sdgecko_preIO(s32 drv_no);
 s32 sdgecko_readCID(s32 drv_no);

--- a/libogc/aram.c
+++ b/libogc/aram.c
@@ -87,7 +87,7 @@ ARCallback AR_RegisterCallback(ARCallback callback)
 	return old;
 }
 
-u32 AR_GetDMAStatus()
+u32 AR_GetDMAStatus(void)
 {
 	u32 level,ret;
 	_CPU_ISR_Disable(level);
@@ -203,32 +203,32 @@ void AR_Clear(u32 flag)
 	}
 }
 
-BOOL AR_CheckInit()
+BOOL AR_CheckInit(void)
 {
 	return __ARInit_Flag;
 }
 
-void AR_Reset()
+void AR_Reset(void)
 {
 	__ARInit_Flag = 0;
 }
 
-u32 AR_GetSize()
+u32 AR_GetSize(void)
 {
 	return __ARSize;
 }
 
-u32 AR_GetBaseAddress()
+u32 AR_GetBaseAddress(void)
 {
 	return 0x4000;
 }
 
-u32 AR_GetInternalSize()
+u32 AR_GetInternalSize(void)
 {
 	return __ARInternalSize;
 }
 
-static __inline__ void __ARClearInterrupt()
+static __inline__ void __ARClearInterrupt(void)
 {
 	u16 cause;
 
@@ -239,7 +239,7 @@ static __inline__ void __ARClearInterrupt()
 	_dspReg[5] = (cause|DSPCR_ARINT);
 }
 
-static __inline__ void __ARWaitDma()
+static __inline__ void __ARWaitDma(void)
 {
 	while(_dspReg[5]&DSPCR_DSPDMA);
 }
@@ -310,7 +310,7 @@ static void __ARClearArea(u32 aramaddr,u32 len)
 	}
 }
 
-static void __ARCheckSize()
+static void __ARCheckSize(void)
 {
 	u32 i,arsize,arszflag;
 	static u32 test_data[8] ATTRIBUTE_ALIGN(32);

--- a/libogc/arqueue.c
+++ b/libogc/arqueue.c
@@ -49,7 +49,7 @@ static ARQRequest *__ARQReqPendingHi;
 static ARQCallback __ARQCallbackLo = NULL;
 static ARQCallback __ARQCallbackHi = NULL;
 
-static __inline__ void __ARQPopTaskQueueHi()
+static __inline__ void __ARQPopTaskQueueHi(void)
 {
 	ARQRequest *req;
 
@@ -74,7 +74,7 @@ static void __ARQCallbackSync(ARQRequest *req)
 	LWP_ThreadBroadcast(__ARQSyncQueue);
 }
 
-static void __ARQServiceQueueLo()
+static void __ARQServiceQueueLo(void)
 {
 	ARQRequest *req;
 
@@ -101,7 +101,7 @@ static void __ARQServiceQueueLo()
 	}
 }
 
-static void __ARInterruptServiceRoutine()
+static void __ARInterruptServiceRoutine(void)
 {
 	if(__ARQCallbackHi) {
 		__ARQReqPendingHi->state = ARQ_TASK_FINISHED;
@@ -118,7 +118,7 @@ static void __ARInterruptServiceRoutine()
 	if(!__ARQReqPendingHi) __ARQServiceQueueLo();
 }
 
-void ARQ_Init()
+void ARQ_Init(void)
 {
 	u32 level;
 #ifdef _ARQ_DEBUG
@@ -146,7 +146,7 @@ void ARQ_Init()
 	_CPU_ISR_Restore(level);
 }
 
-void ARQ_Reset()
+void ARQ_Reset(void)
 {
 	u32 level;
 	_CPU_ISR_Disable(level);
@@ -162,12 +162,12 @@ void ARQ_SetChunkSize(u32 size)
 	_CPU_ISR_Restore(level);
 }
 
-u32 ARQ_GetChunkSize()
+u32 ARQ_GetChunkSize(void)
 {
 	return __ARQChunkSize;
 }
 
-void ARQ_FlushQueue()
+void ARQ_FlushQueue(void)
 {
 	u32 level;
 

--- a/libogc/audio.c
+++ b/libogc/audio.c
@@ -142,7 +142,7 @@ static void __AIDHandler(u32 nIrq,void *pCtx)
 	}
 }
 
-static void __AISRCINIT()
+static void __AISRCINIT(void)
 {
 	int done = 0;
 	u32 sample_counter;
@@ -287,7 +287,7 @@ void AUDIO_SetStreamVolLeft(u8 vol)
 	_aiReg[1] = (_aiReg[1]&~0x000000ff)|(vol&0xff);
 }
 
-u8 AUDIO_GetStreamVolLeft()
+u8 AUDIO_GetStreamVolLeft(void)
 {
 	return (u8)(_aiReg[1]&0xff);
 }
@@ -297,7 +297,7 @@ void AUDIO_SetStreamVolRight(u8 vol)
 	_aiReg[1] = (_aiReg[1]&~0x0000ff00)|(_SHIFTL(vol,8,8));
 }
 
-u8 AUDIO_GetStreamVolRight()
+u8 AUDIO_GetStreamVolRight(void)
 {
 	return (u8)(_SHIFTR(_aiReg[1],8,8));
 }
@@ -307,7 +307,7 @@ void AUDIO_SetStreamSampleRate(u32 rate)
 	_aiReg[AI_CONTROL] = (_aiReg[AI_CONTROL]&~AI_AISFR)|(_SHIFTL(rate,1,1));
 }
 
-u32 AUDIO_GetStreamSampleRate()
+u32 AUDIO_GetStreamSampleRate(void)
 {
 	return _SHIFTR(_aiReg[AI_CONTROL],1,1);
 }
@@ -317,7 +317,7 @@ void AUDIO_SetStreamTrigger(u32 cnt)
 	_aiReg[3] = cnt;
 }
 
-void AUDIO_ResetStreamSampleCnt()
+void AUDIO_ResetStreamSampleCnt(void)
 {
 	_aiReg[AI_CONTROL] = (_aiReg[AI_CONTROL]&~AI_SCRESET)|AI_SCRESET;
 }
@@ -347,7 +347,7 @@ void AUDIO_SetStreamPlayState(u32 state)
 	}
 }
 
-u32 AUDIO_GetStreamPlayState()
+u32 AUDIO_GetStreamPlayState(void)
 {
 	return (_aiReg[AI_CONTROL]&AI_PSTAT);
 }
@@ -376,32 +376,32 @@ void AUDIO_InitDMA(u32 startaddr,u32 len)
 	_CPU_ISR_Restore(level);
 }
 
-u16 AUDIO_GetDMAEnableFlag()
+u16 AUDIO_GetDMAEnableFlag(void)
 {
 	return (_SHIFTR(_dspReg[27],15,1));
 }
 
-void AUDIO_StartDMA()
+void AUDIO_StartDMA(void)
 {
 	_dspReg[27] = (_dspReg[27]&~0x8000)|0x8000;
 }
 
-void AUDIO_StopDMA()
+void AUDIO_StopDMA(void)
 {
 	_dspReg[27] = (_dspReg[27]&~0x8000);
 }
 
-u32 AUDIO_GetDMABytesLeft()
+u32 AUDIO_GetDMABytesLeft(void)
 {
 	return (_SHIFTL(_dspReg[29],5,15));
 }
 
-u32 AUDIO_GetDMAStartAddr()
+u32 AUDIO_GetDMAStartAddr(void)
 {
 	return (_SHIFTL((_dspReg[24]&0x1fff),16,13)|(_dspReg[25]&0xffe0));
 }
 
-u32 AUDIO_GetDMALength()
+u32 AUDIO_GetDMALength(void)
 {
 	return ((_dspReg[27]&0x7fff)<<5);
 }
@@ -421,7 +421,7 @@ void AUDIO_SetDSPSampleRate(u8 rate)
 	}
 }
 
-u32 AUDIO_GetDSPSampleRate()
+u32 AUDIO_GetDSPSampleRate(void)
 {
 	return (_SHIFTR(_aiReg[AI_CONTROL],6,1))^1;		//0^1(1) = 48Khz, 1^1(0) = 32Khz
 }

--- a/libogc/cache.c
+++ b/libogc/cache.c
@@ -37,11 +37,11 @@ distribution.
 #define _SHIFTR(v, s, w)	\
     ((u32)(((u32)(v) >> (s)) & ((0x01 << (w)) - 1)))
 
-extern void __LCEnable();
-extern void L2GlobalInvalidate();
-extern void L2Enable();
+extern void __LCEnable(void);
+extern void L2GlobalInvalidate(void);
+extern void L2Enable(void);
 
-void LCEnable()
+void LCEnable(void)
 {
 	u32 level;
 
@@ -94,7 +94,7 @@ u32 LCStoreData(void *dstAddr,void *srcAddr,u32 nCount)
 	return blocks;
 }
 
-u32 LCQueueLength()
+u32 LCQueueLength(void)
 {
 	u32 hid2 = mfspr(920);
 	return _SHIFTR(hid2,4,4);
@@ -107,7 +107,7 @@ u32 LCQueueWait(u32 len)
 	return len;
 }
 
-void LCFlushQueue()
+void LCFlushQueue(void)
 {
 	mtspr(922,0);
 	mtspr(923,1);
@@ -142,7 +142,7 @@ void LCAllocNoInvalidate(void *addr,u32 bytes)
 	LCAllocTags(FALSE,addr,cnt);
 }
 #ifdef HW_RVL
-void L2Enhance()
+void L2Enhance(void)
 {
 	u32 level, hid4;
 	u32 *stub = (u32*)0x80001800;

--- a/libogc/card.c
+++ b/libogc/card.c
@@ -253,10 +253,10 @@ static sys_resetinfo card_resetinfo = {
 	127
 };
 
-extern unsigned long gettick();
-extern long long gettime();
-extern syssram* __SYS_LockSram();
-extern syssramex* __SYS_LockSramEx();
+extern unsigned long gettick(void);
+extern long long gettime(void);
+extern syssram* __SYS_LockSram(void);
+extern syssramex* __SYS_LockSramEx(void);
 extern u32 __SYS_UnlockSram(u32 write);
 extern u32 __SYS_UnlockSramEx(u32 write);
 
@@ -2056,13 +2056,13 @@ static __inline__ void __card_srand(u32 val)
 	crand_next = val;	
 }
 
-static __inline__ u32 __card_rand()
+static __inline__ u32 __card_rand(void)
 {
 	crand_next = (crand_next*0x41C64E6D)+12345;
 	return _SHIFTR(crand_next,16,15);
 }
 
-static u32 __card_initval()
+static u32 __card_initval(void)
 {
 	u32 ticks = gettick();
 	
@@ -2070,7 +2070,7 @@ static u32 __card_initval()
 	return ((0x7FEC8000|__card_rand())&~0x00000fff);
 }
 
-static u32 __card_dummylen()
+static u32 __card_dummylen(void)
 {
 	u32 ticks = gettick();
 	u32 val = 0,cnt = 0,shift = 1;

--- a/libogc/cond.c
+++ b/libogc/cond.c
@@ -56,7 +56,7 @@ lwp_objinfo _lwp_cond_objects;
 extern int clock_gettime(struct timespec *tp);
 extern void timespec_subtract(const struct timespec *tp_start,const struct timespec *tp_end,struct timespec *result);
 
-void __lwp_cond_init()
+void __lwp_cond_init(void)
 {
 	__lwp_objmgr_initinfo(&_lwp_cond_objects,LWP_MAX_CONDVARS,sizeof(cond_st));
 }
@@ -73,7 +73,7 @@ static __inline__ void __lwp_cond_free(cond_st *cond)
 	__lwp_objmgr_free(&_lwp_cond_objects,&cond->object);
 }
 
-static cond_st* __lwp_cond_allocate()
+static cond_st* __lwp_cond_allocate(void)
 {
 	cond_st *cond;
 

--- a/libogc/console.c
+++ b/libogc/console.c
@@ -225,7 +225,7 @@ static void __console_clear(void)
 	con->saved_row = 0;
 	con->saved_col = 0;
 }
-static void __console_clear_from_cursor() {
+static void __console_clear_from_cursor(void) {
 	console_data_s *con;
 	int cur_row;
 	
@@ -238,7 +238,7 @@ static void __console_clear_from_cursor() {
     __console_clear_line( cur_row, 0, con->con_cols );
   
 }
-static void __console_clear_to_cursor() {
+static void __console_clear_to_cursor(void) {
 	console_data_s *con;
 	int cur_row;
 	

--- a/libogc/decrementer.c
+++ b/libogc/decrementer.c
@@ -43,7 +43,7 @@ distribution.
 extern int printk(const char *fmt,...);
 #endif
 
-void __decrementer_init()
+void __decrementer_init(void)
 {
 #ifdef _DECEX_DEBUG
 	printf("__decrementer_init()\n\n");

--- a/libogc/dsp.c
+++ b/libogc/dsp.c
@@ -211,7 +211,7 @@ static void __dsp_exectask(dsptask_t *exec,dsptask_t *hire)
 	while(DSP_CheckMailTo());
 }
 
-static void __dsp_def_taskcb()
+static void __dsp_def_taskcb(void)
 {
 	u32 mail;
 #ifdef _DSP_DEBUG
@@ -324,7 +324,7 @@ static void __dsp_inthandler(u32 nIrq,void *pCtx)
 	if(__dsp_intcb) __dsp_intcb();
 }
 
-void DSP_Init()
+void DSP_Init(void)
 {
 	u32 level;
 #ifdef _DSP_DEBUG
@@ -367,7 +367,7 @@ DSPCallback DSP_RegisterCallback(DSPCallback usr_cb)
 	return ret;
 }
 
-u32 DSP_CheckMailTo()
+u32 DSP_CheckMailTo(void)
 {
 	u32 sent_mail;
 	sent_mail = _SHIFTR(_dspReg[0],15,1);
@@ -377,7 +377,7 @@ u32 DSP_CheckMailTo()
 	return sent_mail;
 }
 
-u32 DSP_CheckMailFrom()
+u32 DSP_CheckMailFrom(void)
 {
 	u32 has_mail;
 	has_mail = _SHIFTR(_dspReg[2],15,1);
@@ -387,7 +387,7 @@ u32 DSP_CheckMailFrom()
 	return has_mail;
 }
 
-u32 DSP_ReadMailFrom()
+u32 DSP_ReadMailFrom(void)
 {
 	u32 mail;
 	mail = (_SHIFTL(_dspReg[2],16,16)|(_dspReg[3]&0xffff));
@@ -406,7 +406,7 @@ void DSP_SendMailTo(u32 mail)
 	_dspReg[1] = (mail&0xffff);
 }
 
-u32 DSP_ReadCPUtoDSP()
+u32 DSP_ReadCPUtoDSP(void)
 {
 	u32 cpu_dsp;
 	cpu_dsp = (_SHIFTL(_dspReg[0],16,16)|(_dspReg[1]&0xffff));
@@ -416,7 +416,7 @@ u32 DSP_ReadCPUtoDSP()
 	return cpu_dsp;
 }
 
-void DSP_AssertInt()
+void DSP_AssertInt(void)
 {
 	u32 level;
 #ifdef _DSP_DEBUG
@@ -427,7 +427,7 @@ void DSP_AssertInt()
 	_CPU_ISR_Restore(level);
 }
 
-void DSP_Reset()
+void DSP_Reset(void)
 {
 	u16 old;
 	u32 level;
@@ -438,7 +438,7 @@ void DSP_Reset()
 	_CPU_ISR_Restore(level);
 }
 
-void DSP_Halt()
+void DSP_Halt(void)
 {
 	u32 level,old;
 
@@ -448,7 +448,7 @@ void DSP_Halt()
 	_CPU_ISR_Restore(level);
 }
 
-void DSP_Unhalt()
+void DSP_Unhalt(void)
 {
 	u32 level;
 
@@ -457,7 +457,7 @@ void DSP_Unhalt()
 	_CPU_ISR_Restore(level);
 }
 
-u32 DSP_GetDMAStatus()
+u32 DSP_GetDMAStatus(void)
 {
 	return _dspReg[5]&DSPCR_DSPDMA;
 }

--- a/libogc/dvd.c
+++ b/libogc/dvd.c
@@ -432,7 +432,7 @@ static u8 convert(u32 errorcode)
 	return err_num+(err*30);
 }
 
-static void __dvd_clearwaitingqueue()
+static void __dvd_clearwaitingqueue(void)
 {
 	u32 i;
 
@@ -440,7 +440,7 @@ static void __dvd_clearwaitingqueue()
 		__lwp_queue_init_empty(&__dvd_waitingqueue[i]);
 }
 
-static s32 __dvd_checkwaitingqueue()
+static s32 __dvd_checkwaitingqueue(void)
 {
 	u32 i;
 	u32 level;
@@ -481,7 +481,7 @@ static dvdcmdblk* __dvd_popwaitingqueueprio(s32 prio)
 	return ret;
 }
 
-static dvdcmdblk* __dvd_popwaitingqueue()
+static dvdcmdblk* __dvd_popwaitingqueue(void)
 {
 	u32 i,level;
 	dvdcmdblk *ret = NULL;
@@ -599,7 +599,7 @@ static void __DoRead(void *buffer,u32 len,s64 offset,dvdcallbacklow cb)
 	__Read(buffer,len,offset,cb);
 }
 
-static u32 __ProcessNextCmd()
+static u32 __ProcessNextCmd(void)
 {
 	u32 cmd_num;
 #ifdef _DVD_DEBUG
@@ -630,7 +630,7 @@ static void __DVDLowWATypeSet(u32 workaround,u32 workaroundseek)
 	_CPU_ISR_Restore(level);
 }
 
-static void __DVDInitWA()
+static void __DVDInitWA(void)
 {
 	__dvd_nextcmdnum = 0;
 	__DVDLowWATypeSet(0,0);
@@ -1266,7 +1266,7 @@ static void __dvd_fwpatchmem(dvdcallbacklow cb)
 	return;
 }
 
-static void __dvd_handlespinup()
+static void __dvd_handlespinup(void)
 {
 #ifdef _DVD_DEBUG
 	printf("__dvd_handlespinup()\n");
@@ -1568,7 +1568,7 @@ void __dvd_statebusy(dvdcmdblk *block)
 	}
 }
 
-void __dvd_stateready()
+void __dvd_stateready(void)
 {
 	dvdcmdblk *block;
 #ifdef _DVD_DEBUG
@@ -1635,7 +1635,7 @@ void __dvd_stateready()
 	__dvd_statebusy(__dvd_executing);
 }
 
-void __dvd_statecoverclosed()
+void __dvd_statecoverclosed(void)
 {
 	dvdcmdblk *blk;
 #ifdef _DVD_DEBUG
@@ -1663,7 +1663,7 @@ void __dvd_statecoverclosed_cmd(dvdcmdblk *block)
 	DVD_LowReadId(&__dvd_tmpid0,__dvd_statecoverclosedcb);
 }
 
-void __dvd_statemotorstopped()
+void __dvd_statemotorstopped(void)
 {
 #ifdef _DVD_DEBUG
 	printf("__dvd_statemotorstopped(%d)\n",__dvd_executing->state);
@@ -1680,7 +1680,7 @@ void __dvd_stateerror(s32 result)
 	DVD_LowStopMotor(__dvd_stateerrorcb);
 }
 
-void __dvd_stategettingerror()
+void __dvd_stategettingerror(void)
 {
 #ifdef _DVD_DEBUG
 	printf("__dvd_stategettingerror()\n");
@@ -1693,7 +1693,7 @@ void __dvd_statecheckid2(dvdcmdblk *block)
 
 }
 
-void __dvd_statecheckid()
+void __dvd_statecheckid(void)
 {
 	dvdcmdblk *blk;
 #ifdef _DVD_DEBUG
@@ -1732,14 +1732,14 @@ void __dvd_statecheckid()
 	__dvd_statebusy(__dvd_executing);
 }
 
-void __dvd_statetimeout()
+void __dvd_statetimeout(void)
 {
 	__dvd_storeerror(0x01234568);
 	DVD_Reset(DVD_RESETSOFT);
 	__dvd_stateerrorcb(0);
 }
 
-void __dvd_stategotoretry()
+void __dvd_stategotoretry(void)
 {
 	DVD_LowStopMotor(__dvd_stategotoretrycb);
 }
@@ -2498,7 +2498,7 @@ s32 DVD_GetCmdBlockStatus(dvdcmdblk *block)
 	return ret;
 }
 
-s32 DVD_GetDriveStatus()
+s32 DVD_GetDriveStatus(void)
 {
 	s32 ret;
 	u32 level;
@@ -2516,7 +2516,7 @@ s32 DVD_GetDriveStatus()
 	return ret;
 }
 
-void DVD_Pause()
+void DVD_Pause(void)
 {
 	u32 level;
 
@@ -2572,7 +2572,7 @@ s32 DVD_MountAsync(dvdcmdblk *block,dvdcbcallback cb)
 	return DVD_SpinUpDriveAsync(block,callback);
 }
 
-s32 DVD_Mount()
+s32 DVD_Mount(void)
 {
 	s32 ret = 0;
 	s32 state;
@@ -2598,17 +2598,17 @@ s32 DVD_Mount()
 	return ret;
 }
 
-dvddiskid* DVD_GetCurrentDiskID()
+dvddiskid* DVD_GetCurrentDiskID(void)
 {
 	return __dvd_diskID;
 }
 
-dvddrvinfo* DVD_GetDriveInfo()
+dvddrvinfo* DVD_GetDriveInfo(void)
 {
 	return &__dvd_driveinfo;
 }
 
-void DVD_Init()
+void DVD_Init(void)
 {
 #ifdef _DVD_DEBUG
 	printf("DVD_Init()\n");
@@ -2633,7 +2633,7 @@ u32 DVD_SetAutoInvalidation(u32 auto_inv)
 	return ret;
 }
 
-static bool dvdio_Startup()
+static bool dvdio_Startup(void)
 {
 	DVD_Init();
 
@@ -2649,7 +2649,7 @@ static bool dvdio_Startup()
 	return true;
 }
 
-static bool dvdio_IsInserted()
+static bool dvdio_IsInserted(void)
 {
 	u32 status = 0;
 	DVD_LowGetStatus(&status, NULL);
@@ -2675,12 +2675,12 @@ static bool dvdio_WriteSectors(sec_t sector,sec_t numSectors,const void *buffer)
 	return true;
 }
 
-static bool dvdio_ClearStatus()
+static bool dvdio_ClearStatus(void)
 {
 	return true;
 }
 
-static bool dvdio_Shutdown()
+static bool dvdio_Shutdown(void)
 {
 	return true;
 }

--- a/libogc/exception.c
+++ b/libogc/exception.c
@@ -69,7 +69,7 @@ extern void irq_exceptionhandler();
 extern void dec_exceptionhandler();
 extern void default_exceptionhandler();
 extern void VIDEO_SetFramebuffer(void *);
-extern void __reload();
+extern void __reload(void);
 
 extern s8 exceptionhandler_start[],exceptionhandler_end[],exceptionhandler_patch[];
 extern s8 systemcallhandler_start[],systemcallhandler_end[];
@@ -100,12 +100,12 @@ void __exception_load(u32 nExc,void *data,u32 len,void *patch)
 	_sync();
 }
 
-void __systemcall_init()
+void __systemcall_init(void)
 {
 	__exception_load(EX_SYS_CALL,systemcallhandler_start,(systemcallhandler_end-systemcallhandler_start),NULL);
 }
 
-void __exception_init()
+void __exception_init(void)
 {
 	s32 i;
 #ifdef _EXC_DEBUG
@@ -140,7 +140,7 @@ void __exception_close(u32 except)
 	_CPU_ISR_Restore(level);
 }
 
-void __exception_closeall()
+void __exception_closeall(void)
 {
 	s32 i;
 
@@ -195,7 +195,7 @@ void __exception_setreload(int t)
 	reload_timer = t*50;
 }
 
-static void waitForReload()
+static void waitForReload(void)
 {
 	u32 level;
 

--- a/libogc/exi.c
+++ b/libogc/exi.c
@@ -716,7 +716,7 @@ s32 EXI_ProbeEx(s32 nChn)
 	return 0;
 }
 
-void EXI_ProbeReset()
+void EXI_ProbeReset(void)
 {
 	last_exi_idtime[0] = 0;
 	last_exi_idtime[1] = 0;
@@ -729,7 +729,7 @@ void EXI_ProbeReset()
 	EXI_GetID(EXI_CHANNEL_0,EXI_DEVICE_2,&exi_id_serport1);
 }
 
-void __exi_init()
+void __exi_init(void)
 {
 #ifdef _EXI_DEBUG
 	printf("__exi_init(): init expansion system.\n");
@@ -866,7 +866,7 @@ static s32 __probebarnacle(s32 chn,u32 dev,u32 *rev)
 	return 1;
 }
 
-static s32 __queuelength()
+static s32 __queuelength(void)
 {
 	u32 reg;
 	u8 len = 0;
@@ -906,7 +906,7 @@ void __SYS_EnableBarnacle(s32 chn,u32 dev)
 	exi_uart_enabled = 0xa5ff005a;
 }
 
-s32 InitializeUART()
+s32 InitializeUART(void)
 {
 	if((exi_uart_enabled+0x5a010000)==0x005a) return 0;
 

--- a/libogc/gx.c
+++ b/libogc/gx.c
@@ -147,23 +147,23 @@ static sys_resetinfo __gx_resetinfo = {
 extern int printk(const char *fmt,...);
 #endif
 
-static __inline__ BOOL IsWriteGatherBufferEmpty()
+static __inline__ BOOL IsWriteGatherBufferEmpty(void)
 {
 	return !(mfwpar()&1);
 }
 
-static __inline__ void DisableWriteGatherPipe()
+static __inline__ void DisableWriteGatherPipe(void)
 {
 	mthid2((mfhid2()&~0x40000000));
 }
 
-static __inline__ void EnableWriteGatherPipe()
+static __inline__ void EnableWriteGatherPipe(void)
 {
 	mtwpar(0x0C008000);
 	mthid2((mfhid2()|0x40000000));
 }
 
-static __inline__ void __GX_ResetWriteGatherPipe()
+static __inline__ void __GX_ResetWriteGatherPipe(void)
 {
 	while(mfwpar()&1);
 	mtwpar(0x0C008000);
@@ -187,13 +187,13 @@ static __inline__ void __GX_WriteFifoIntEnable(u8 inthi, u8 intlo)
 	_cpReg[1] = __gx->cpCRreg;
 }
 
-static __inline__ void __GX_FifoReadEnable()
+static __inline__ void __GX_FifoReadEnable(void)
 {
 	__gx->cpCRreg = ((__gx->cpCRreg&~0x01)|1);
 	_cpReg[1] = __gx->cpCRreg;
 }
 
-static __inline__ void __GX_FifoReadDisable()
+static __inline__ void __GX_FifoReadDisable(void)
 {
 	__gx->cpCRreg = ((__gx->cpCRreg&~0x01)|0);
 	_cpReg[1] = __gx->cpCRreg;
@@ -209,23 +209,23 @@ static s32 __gx_onreset(s32 final)
 }
 
 #if 0
-static u32 __GX_IsGPCPUFifoLinked()
+static u32 __GX_IsGPCPUFifoLinked(void)
 {
 	return _cpgplinked;
 }
 
-static u32 __GX_IsCPUFifoReady()
+static u32 __GX_IsCPUFifoReady(void)
 {
 	return _gxcpufifoready;
 }
 #endif
 
-static u32 __GX_IsGPFifoReady()
+static u32 __GX_IsGPFifoReady(void)
 {
 	return _gxgpfifoready;
 }
 
-static u32 __GX_CPGPLinkCheck()
+static u32 __GX_CPGPLinkCheck(void)
 {
 	struct __gxfifo *gpfifo = (struct __gxfifo*)&_gpfifo;
 	struct __gxfifo *cpufifo = (struct __gxfifo*)&_cpufifo;
@@ -237,7 +237,7 @@ static u32 __GX_CPGPLinkCheck()
 	return 0;
 }
 
-static void __GX_InitRevBits()
+static void __GX_InitRevBits(void)
 {
 	s32 i;
 
@@ -281,7 +281,7 @@ static u32 __GX_ReadMemCounterU32(u32 reg)
 	return (u32)((ucnt<<16)|lcnt);
 }
 
-static void __GX_WaitAbortPixelEngine()
+static void __GX_WaitAbortPixelEngine(void)
 {
 	u32 cnt,tmp;
 
@@ -293,7 +293,7 @@ static void __GX_WaitAbortPixelEngine()
 	} while(cnt!=tmp);
 }
 
-static void __GX_Abort()
+static void __GX_Abort(void)
 {
 	if(__gx->gxFifoInited && __GX_IsGPFifoReady())
 		__GX_WaitAbortPixelEngine();
@@ -306,7 +306,7 @@ static void __GX_Abort()
 }
 #endif
 
-static void __GX_SaveFifo()
+static void __GX_SaveFifo(void)
 {
 	s32 rdwt_dst;
 	u32 level,val;
@@ -339,7 +339,7 @@ static void __GX_SaveFifo()
 	_CPU_ISR_Restore(level);
 }
 
-static void __GX_CleanGPFifo()
+static void __GX_CleanGPFifo(void)
 {
 	u32 level;
 	struct __gxfifo *gpfifo = (struct __gxfifo*)&_gpfifo;
@@ -385,7 +385,7 @@ static void __GX_CleanGPFifo()
 	_CPU_ISR_Restore(level);
 }
 
-static void __GXOverflowHandler()
+static void __GXOverflowHandler(void)
 {
 	if(!_gxoverflowsuspend) {
 		_gxoverflowsuspend = 1;
@@ -396,7 +396,7 @@ static void __GXOverflowHandler()
 	}
 }
 
-static void __GXUnderflowHandler()
+static void __GXUnderflowHandler(void)
 {
 	if(_gxoverflowsuspend) {
 		_gxoverflowsuspend = 0;
@@ -448,7 +448,7 @@ static void __GXFinishInterruptHandler(u32 irq,void *ctx)
 	LWP_ThreadBroadcast(_gxwaitfinish);
 }
 
-static void __GX_PEInit()
+static void __GX_PEInit(void)
 {
 	IRQ_Request(IRQ_PI_PETOKEN,__GXTokenInterruptHandler,NULL);
 	__UnmaskIrq(IRQMASK(IRQ_PI_PETOKEN));
@@ -459,7 +459,7 @@ static void __GX_PEInit()
 	_peReg[5] = 0x0F;
 }
 
-static void __GX_FifoInit()
+static void __GX_FifoInit(void)
 {
 	IRQ_Request(IRQ_PI_CP,__GXCPInterruptHandler,NULL);
 	__UnmaskIrq(IRQMASK(IRQ_PI_CP));
@@ -594,7 +594,7 @@ static GXTlutRegion* __GXDefTlutRegionCallback(u32 tlut_name)
 	return &__gx->tlutRegion[tlut_name];
 }
 
-static void __GX_InitGX()
+static void __GX_InitGX(void)
 {
 	s32 i;
 	u32 flag;
@@ -742,12 +742,12 @@ static void __GX_InitGX()
 	GX_ClearGPMetric();
 }
 
-static void __GX_FlushTextureState()
+static void __GX_FlushTextureState(void)
 {
 	GX_LOAD_BP_REG(__gx->tevIndMask);
 }
 
-static void __GX_XfVtxSpecs()
+static void __GX_XfVtxSpecs(void)
 {
 	u32 xfvtxspecs = 0;
 	u32 nrms,texs,cols;
@@ -785,7 +785,7 @@ static void __GX_SetMatrixIndex(u32 mtx)
 	}
 }
 
-static void __GX_SendFlushPrim()
+static void __GX_SendFlushPrim(void)
 {
 	u32 tmp,tmp2,cnt;
 
@@ -819,14 +819,14 @@ static void __GX_SendFlushPrim()
 	__gx->xfFlush = 1;
 }
 
-static void __GX_SetVCD()
+static void __GX_SetVCD(void)
 {
 	GX_LOAD_CP_REG(0x50,__gx->vcdLo);
 	GX_LOAD_CP_REG(0x60,__gx->vcdHi);
 	__GX_XfVtxSpecs();
 }
 
-static void __GX_SetVAT()
+static void __GX_SetVAT(void)
 {
 	u8 setvtx = 0;
 	s32 i;
@@ -863,7 +863,7 @@ static void __SetSURegs(u8 texmap,u8 texcoord)
 	GX_LOAD_BP_REG(__gx->suTsize[reg]);
 }
 
-static void __GX_SetSUTexRegs()
+static void __GX_SetSUTexRegs(void)
 {
 	u32 i;
 	u32 indtev,dirtev;
@@ -919,13 +919,13 @@ static void __GX_SetSUTexRegs()
 	}
 }
 
-static void __GX_SetGenMode()
+static void __GX_SetGenMode(void)
 {
 	GX_LOAD_BP_REG(__gx->genMode);
 	__gx->xfFlush = 0;
 }
 
-static void __GX_UpdateBPMask()
+static void __GX_UpdateBPMask(void)
 {
 #if defined(HW_DOL)
 	u32 i;
@@ -969,7 +969,7 @@ static void __GX_SetIndirectMask(u32 mask)
 	GX_LOAD_BP_REG(__gx->tevIndMask);
 }
 
-static void __GX_SetTexCoordGen()
+static void __GX_SetTexCoordGen(void)
 {
 	u32 i,mask;
 	u32 texcoord;
@@ -990,7 +990,7 @@ static void __GX_SetTexCoordGen()
 	}
 }
 
-static void __GX_SetChanColor()
+static void __GX_SetChanColor(void)
 {
 	if(__gx->dirtyState&0x0100)
 		GX_LOAD_XF_REG(0x100a,__gx->chnAmbColor[0]);
@@ -1002,7 +1002,7 @@ static void __GX_SetChanColor()
 		GX_LOAD_XF_REG(0x100d,__gx->chnMatColor[1]);
 }
 
-static void __GX_SetChanCntrl()
+static void __GX_SetChanCntrl(void)
 {
 	u32 i,chan,mask;
 
@@ -1020,7 +1020,7 @@ static void __GX_SetChanCntrl()
 	}
 }
 
-static void __GX_SetDirtyState()
+static void __GX_SetDirtyState(void)
 {
 	if(__gx->dirtyState&0x0001) {
 		__GX_SetSUTexRegs();
@@ -1495,24 +1495,24 @@ u8 GX_GetFifoWrap(GXFifoObj *fifo)
 	return ((struct __gxfifo*)fifo)->fifo_wrap;
 }
 
-u32 GX_GetOverflowCount()
+u32 GX_GetOverflowCount(void)
 {
 	return _gxoverflowcount;
 }
 
-u32 GX_ResetOverflowCount()
+u32 GX_ResetOverflowCount(void)
 {
 	u32 ret = _gxoverflowcount;
 	_gxoverflowcount = 0;
 	return ret;
 }
 
-lwp_t GX_GetCurrentGXThread()
+lwp_t GX_GetCurrentGXThread(void)
 {
 	return _gxcurrentlwp;
 }
 
-lwp_t GX_SetCurrentGXThread()
+lwp_t GX_SetCurrentGXThread(void)
 {
 	u32 level;
 
@@ -1550,7 +1550,7 @@ volatile void* GX_RedirectWriteGatherPipe(void *ptr)
 	return (volatile void*)0x0C008000;
 }
 
-void GX_RestoreWriteGatherPipe()
+void GX_RestoreWriteGatherPipe(void)
 {
 	u32 level;
 	struct __gxfifo *cpufifo = (struct __gxfifo*)&_cpufifo;
@@ -1581,7 +1581,7 @@ void GX_RestoreWriteGatherPipe()
 	_CPU_ISR_Restore(level);
 }
 
-void GX_Flush()
+void GX_Flush(void)
 {
 	if(__gx->dirtyState)
 		__GX_SetDirtyState();
@@ -1612,7 +1612,7 @@ void GX_EnableBreakPt(void *break_pt)
  	_CPU_ISR_Restore(level);
 }
 
-void GX_DisableBreakPt()
+void GX_DisableBreakPt(void)
 {
 	u32 level = 0;
 	_CPU_ISR_Disable(level);
@@ -1623,7 +1623,7 @@ void GX_DisableBreakPt()
 }
 
 #if defined(HW_DOL)
-void GX_AbortFrame()
+void GX_AbortFrame(void)
 {
 	_piReg[6] = 1;
 	__GX_WaitAbort(50);
@@ -1634,7 +1634,7 @@ void GX_AbortFrame()
 		__GX_CleanGPFifo();
 }
 #elif defined(HW_RVL)
-void GX_AbortFrame()
+void GX_AbortFrame(void)
 {
 	__GX_Abort();
 	if(__GX_IsGPFifoReady()) {
@@ -1657,12 +1657,12 @@ void GX_SetDrawSync(u16 token)
 	_CPU_ISR_Restore(level);
 }
 
-u16 GX_GetDrawSync()
+u16 GX_GetDrawSync(void)
 {
 	return _peReg[7];
 }
 
-void GX_SetDrawDone()
+void GX_SetDrawDone(void)
 {
 	u32 level;
 	_CPU_ISR_Disable(level);
@@ -1673,7 +1673,7 @@ void GX_SetDrawDone()
 }
 
 
-void GX_WaitDrawDone()
+void GX_WaitDrawDone(void)
 {
 	u32 level;
 #ifdef _GP_DEBUG
@@ -1685,7 +1685,7 @@ void GX_WaitDrawDone()
 	_CPU_ISR_Restore(level);
 }
 
-void GX_DrawDone()
+void GX_DrawDone(void)
 {
 	u32 level;
 
@@ -1734,12 +1734,12 @@ GXBreakPtCallback GX_SetBreakPtCallback(GXBreakPtCallback cb)
 	return ret;
 }
 
-void GX_PixModeSync()
+void GX_PixModeSync(void)
 {
 	GX_LOAD_BP_REG(__gx->peCntrl);
 }
 
-void GX_TexModeSync()
+void GX_TexModeSync(void)
 {
 	GX_LOAD_BP_REG(0x63000000);
 }
@@ -2122,7 +2122,7 @@ void GX_SetTexCopyDst(u16 wd,u16 ht,u32 fmt,u8 mipmap)
 	__gx->texCopyZTex = ((fmt&_GX_TF_ZTF)==_GX_TF_ZTF);
 }
 
-void GX_ClearBoundingBox()
+void GX_ClearBoundingBox(void)
 {
 	GX_LOAD_BP_REG(0x550003ff);
 	GX_LOAD_BP_REG(0x560003ff);
@@ -2154,7 +2154,7 @@ void GX_BeginDispList(void *list,u32 size)
 	__GX_ResetWriteGatherPipe();
 }
 
-u32 GX_EndDispList()
+u32 GX_EndDispList(void)
 {
 	u32 level;
 	u8 wrap = 0;
@@ -2939,7 +2939,7 @@ void GX_SetNumTexGens(u32 nr)
 	__gx->dirtyState |= 0x02000004;
 }
 
-void GX_InvVtxCache()
+void GX_InvVtxCache(void)
 {
 	wgPipe->U8 = 0x48; // vertex cache weg
 }
@@ -3582,7 +3582,7 @@ void GX_PreloadEntireTexture(GXTexObj *obj,GXTexRegion *region)
 	__GX_FlushTextureState();
 }
 
-void GX_InvalidateTexAll()
+void GX_InvalidateTexAll(void)
 {
 	__GX_FlushTextureState();
 	GX_LOAD_BP_REG(0x66001000);
@@ -3730,7 +3730,7 @@ void GX_SetBlendMode(u8 type,u8 src_fact,u8 dst_fact,u8 op)
 	GX_LOAD_BP_REG(__gx->peCMode0);
 }
 
-void GX_ClearVtxDesc()
+void GX_ClearVtxDesc(void)
 {
 	__gx->vcdNrms = 0;
 	__gx->vcdClear = ((__gx->vcdClear&~0x0600)|0x0200);
@@ -5042,12 +5042,12 @@ void GX_SetGPMetric(u32 perf0,u32 perf1)
 
 }
 
-void GX_ClearGPMetric()
+void GX_ClearGPMetric(void)
 {
 	_cpReg[2] = 4;
 }
 
-void GX_InitXfRasMetric()
+void GX_InitXfRasMetric(void)
 {
 	GX_LOAD_BP_REG(0x2402C022);
 	GX_LOAD_XF_REG(0x1006,0x31000);
@@ -5061,7 +5061,7 @@ void GX_ReadXfRasMetric(u32 *xfwaitin,u32 *xfwaitout,u32 *rasbusy,u32 *clks)
 	*xfwaitout = _SHIFTL(_cpReg[39],16,16)|(_cpReg[38]&0xffff);
 }
 
-u32 GX_ReadClksPerVtx()
+u32 GX_ReadClksPerVtx(void)
 {
 	GX_DrawDone();
 	_cpReg[49] = 0x1007;
@@ -5069,7 +5069,7 @@ u32 GX_ReadClksPerVtx()
 	return (_cpReg[50]<<8);
 }
 
-void GX_ClearVCacheMetric()
+void GX_ClearVCacheMetric(void)
 {
 	GX_LOAD_CP_REG(0,0);
 }

--- a/libogc/ios.c
+++ b/libogc/ios.c
@@ -108,7 +108,7 @@ s32 __IOS_ShutdownSubsystems(void)
 	return ret;
 }
 
-s32 IOS_GetPreferredVersion()
+s32 IOS_GetPreferredVersion(void)
 {
 	int ver = IOS_EBADVERSION;
 	s32 res;
@@ -182,7 +182,7 @@ s32 IOS_GetPreferredVersion()
 	return ver;
 }
 
-s32 IOS_GetVersion()
+s32 IOS_GetVersion(void)
 {
 	u32 vercode;
 	u16 version;
@@ -194,7 +194,7 @@ s32 IOS_GetVersion()
 	return version;
 }
 
-s32 IOS_GetRevision()
+s32 IOS_GetRevision(void)
 {
 	u32 vercode;
 	u16 rev;
@@ -205,7 +205,7 @@ s32 IOS_GetRevision()
 	return rev;
 }
 
-s32 IOS_GetRevisionMajor()
+s32 IOS_GetRevisionMajor(void)
 {
 	s32 rev;
 	rev = IOS_GetRevision();
@@ -213,7 +213,7 @@ s32 IOS_GetRevisionMajor()
 	return (rev>>8)&0xFF;
 }
 
-s32 IOS_GetRevisionMinor()
+s32 IOS_GetRevisionMinor(void)
 {
 	s32 rev;
 	rev = IOS_GetRevision();
@@ -326,7 +326,7 @@ s32 __IOS_LaunchNewIOS(int version)
 	return version;
 }
 
-s32 __attribute__((weak)) __IOS_LoadStartupIOS()
+s32 __attribute__((weak)) __IOS_LoadStartupIOS(void)
 {
 #if 0
 	int version;

--- a/libogc/ipc.c
+++ b/libogc/ipc.c
@@ -175,7 +175,7 @@ extern void __UnmaskIrq(u32 nMask);
 extern void* __SYS_GetIPCBufferLo(void);
 extern void* __SYS_GetIPCBufferHi(void);
 
-extern u32 gettick();
+extern u32 gettick(void);
 
 static __inline__ u32 IPC_ReadReg(u32 reg)
 {
@@ -192,7 +192,7 @@ static __inline__ void ACR_WriteReg(u32 reg,u32 val)
 	_ipcReg[reg>>2] = val;
 }
 
-static __inline__ void* __ipc_allocreq()
+static __inline__ void* __ipc_allocreq(void)
 {
 	return iosAlloc(_ipc_hid,IPC_REQUESTSIZE);
 }
@@ -207,7 +207,7 @@ static __inline__ void __ipc_srand(u32 seed)
 	_ipc_seed = seed;
 }
 
-static __inline__ u32 __ipc_rand()
+static __inline__ u32 __ipc_rand(void)
 {
 	_ipc_seed = (214013*_ipc_seed) + 2531011;
 	return _ipc_seed;
@@ -294,7 +294,7 @@ static s32 __ipc_syncqueuerequest(struct _ipcreq *req)
 	return IPC_OK;
 }
 
-static void __ipc_sendrequest()
+static void __ipc_sendrequest(void)
 {
 	u32 cnt;
 	u32 ipc_send;
@@ -326,7 +326,7 @@ static void __ipc_sendrequest()
 	}
 }
 
-static void __ipc_replyhandler()
+static void __ipc_replyhandler(void)
 {
 	u32 ipc_ack,cnt;
 	struct _ipcreq *req = NULL;
@@ -405,7 +405,7 @@ static void __ipc_replyhandler()
 	IPC_WriteReg(1,ipc_ack);
 }
 
-static void __ipc_ackhandler()
+static void __ipc_ackhandler(void)
 {
 	u32 ipc_ack;
 #ifdef DEBUG_IPC
@@ -772,12 +772,12 @@ void iosFree(s32 hid,void *ptr)
 	__lwp_heap_free(&_ipc_heaps[hid].heap,ptr);
 }
 
-void* IPC_GetBufferLo()
+void* IPC_GetBufferLo(void)
 {
 	return _ipc_currbufferlo;
 }
 
-void* IPC_GetBufferHi()
+void* IPC_GetBufferHi(void)
 {
 	return _ipc_currbufferhi;
 }

--- a/libogc/irq.c
+++ b/libogc/irq.c
@@ -395,7 +395,7 @@ void __MaskIrq(u32 nMask)
 	_CPU_ISR_Restore(level);
 }
 
-void __irq_init()
+void __irq_init(void)
 {
 	register u32 intrStack = (u32)__intrstack_addr;
 	register u32 intrStack_end = (u32)__intrstack_end;
@@ -456,7 +456,7 @@ raw_irq_handler_t IRQ_Free(u32 nIrq)
 	return old;
 }
 
-u32 IRQ_Disable()
+u32 IRQ_Disable(void)
 {
 	u32 level;
 	_CPU_ISR_Disable(level);

--- a/libogc/isfs.c
+++ b/libogc/isfs.c
@@ -167,7 +167,7 @@ static s32 __isfsFunctionCB(s32 result,void *usrdata)
 	return result;
 }
 
-s32 ISFS_Initialize()
+s32 ISFS_Initialize(void)
 {
 	s32 ret = IPC_OK;
 
@@ -183,7 +183,7 @@ s32 ISFS_Initialize()
 	return ret;
 }
 
-s32 ISFS_Deinitialize()
+s32 ISFS_Deinitialize(void)
 {
 	if(_fs_fd<0) return ISFS_EINVAL;
 
@@ -366,7 +366,7 @@ s32 ISFS_OpenAsync(const char *filepath,u8 mode,isfscallback cb,void *usrdata)
 	return IOS_OpenAsync(param->filepath,mode,__isfsFunctionCB,param);
 }
 
-s32 ISFS_Format()
+s32 ISFS_Format(void)
 {
 	if(_fs_fd<0) return ISFS_EINVAL;
 

--- a/libogc/lwp.c
+++ b/libogc/lwp.c
@@ -62,7 +62,7 @@ typedef struct _tqueue_st {
 lwp_objinfo _lwp_thr_objects;
 lwp_objinfo _lwp_tqueue_objects;
 
-extern int __crtmain();
+extern int __crtmain(void);
 
 extern u8 __stack_addr[],__stack_end[];
 
@@ -83,7 +83,7 @@ static __inline__ tqueue_st* __lwp_tqueue_open(lwpq_t tqueue)
 	return (tqueue_st*)__lwp_objmgr_get(&_lwp_tqueue_objects,LWP_OBJMASKID(tqueue));
 }
 
-static lwp_cntrl* __lwp_cntrl_allocate()
+static lwp_cntrl* __lwp_cntrl_allocate(void)
 {
 	lwp_cntrl *thethread;
 	
@@ -97,7 +97,7 @@ static lwp_cntrl* __lwp_cntrl_allocate()
 	return NULL;
 }
 
-static tqueue_st* __lwp_tqueue_allocate()
+static tqueue_st* __lwp_tqueue_allocate(void)
 {
 	tqueue_st *tqueue;
 
@@ -129,7 +129,7 @@ static void* idle_func(void *arg)
 	return 0;
 }
 
-void __lwp_sysinit()
+void __lwp_sysinit(void)
 {
 	__lwp_objmgr_initinfo(&_lwp_thr_objects,LWP_MAX_THREADS,sizeof(lwp_cntrl));
 	__lwp_objmgr_initinfo(&_lwp_tqueue_objects,LWP_MAX_TQUEUES,sizeof(tqueue_st));
@@ -164,7 +164,7 @@ BOOL __lwp_thread_isalive(lwp_t thr_id)
 	return FALSE;
 }
 
-lwp_t __lwp_thread_currentid()
+lwp_t __lwp_thread_currentid(void)
 {
 	return _thr_executing->object.id;
 }
@@ -249,7 +249,7 @@ s32 LWP_ResumeThread(lwp_t thethread)
 	return LWP_NOT_SUSPENDED;
 }
 
-lwp_t LWP_GetSelf()
+lwp_t LWP_GetSelf(void)
 {
 	lwp_t ret;
 
@@ -273,7 +273,7 @@ void LWP_SetThreadPriority(lwp_t thethread,u32 prio)
 	__lwp_thread_dispatchenable();
 }
 
-void LWP_YieldThread()
+void LWP_YieldThread(void)
 {
 	__lwp_thread_dispatchdisable();
 	__lwp_thread_yield();

--- a/libogc/lwp_objmgr.c
+++ b/libogc/lwp_objmgr.c
@@ -11,7 +11,7 @@
 static u32 _lwp_objmgr_memsize = 0;
 static lwp_obj *null_local_table = NULL;
 
-u32 __lwp_objmgr_memsize()
+u32 __lwp_objmgr_memsize(void)
 {
 	return _lwp_objmgr_memsize;
 }

--- a/libogc/lwp_priority.c
+++ b/libogc/lwp_priority.c
@@ -3,7 +3,7 @@
 vu32 _prio_major_bitmap;
 u32 _prio_bitmap[16] __attribute__((aligned(32)));
 
-void __lwp_priority_init()
+void __lwp_priority_init(void)
 {
 	u32 index;
 	

--- a/libogc/lwp_priority.inl
+++ b/libogc/lwp_priority.inl
@@ -35,7 +35,7 @@ static __inline__ void __lwp_priomap_removefrom(prio_cntrl *theprio)
 		_prio_major_bitmap &= theprio->block_major;
 }
 
-static __inline__ u32 __lwp_priomap_highest()
+static __inline__ u32 __lwp_priomap_highest(void)
 {
 	u32 major,minor;
 	major = cntlzw(_prio_major_bitmap);

--- a/libogc/lwp_threads.c
+++ b/libogc/lwp_threads.c
@@ -58,7 +58,7 @@ static void __lwp_dumpcontext(frame_context *ctx)
 	kprintf("LR %08x SRR0 %08x SRR1 %08x MSR %08x\n\n", ctx->LR, ctx->SRR0, ctx->SRR1,ctx->MSR);
 }
 
-void __lwp_showmsr()
+void __lwp_showmsr(void)
 {
 	register u32 msr;
 	_CPU_MSR_GET(msr);
@@ -77,7 +77,7 @@ void __lwp_getthreadlist(lwp_obj **thrs)
 	*thrs = _lwp_objects;
 }
 */
-u32 __lwp_isr_in_progress()
+u32 __lwp_isr_in_progress(void)
 {
 	register u32 isr_nest_level;
 	isr_nest_level = mfspr(272);
@@ -95,7 +95,7 @@ static inline void __lwp_msr_setlevel(u32 level)
 	_CPU_MSR_SET(msr);
 }
 
-static inline u32 __lwp_msr_getlevel()
+static inline u32 __lwp_msr_getlevel(void)
 {
 	register u32 msr;
 	_CPU_MSR_GET(msr);
@@ -152,7 +152,7 @@ void __lwp_thread_tickle_timeslice(void *arg)
 	__lwp_thread_dispatchunnest();
 }
 
-void __thread_dispatch_fp()
+void __thread_dispatch_fp(void)
 {
 	u32 level;
 	lwp_cntrl *exec;
@@ -170,7 +170,7 @@ void __thread_dispatch_fp()
 	_CPU_ISR_Restore(level);
 }
 
-void __thread_dispatch()
+void __thread_dispatch(void)
 {
 	u32 level;
 	lwp_cntrl *exec,*heir;
@@ -200,7 +200,7 @@ void __thread_dispatch()
 	_CPU_ISR_Restore(level);
 }
 
-static void __lwp_thread_handler()
+static void __lwp_thread_handler(void)
 {
 	u32 level;
 	lwp_cntrl *exec;
@@ -254,7 +254,7 @@ void __lwp_rotate_readyqueue(u32 prio)
 	_CPU_ISR_Restore(level);
 }
 
-void __lwp_thread_yield()
+void __lwp_thread_yield(void)
 {
 	u32 level;
 	lwp_cntrl *exec;
@@ -276,7 +276,7 @@ void __lwp_thread_yield()
 	_CPU_ISR_Restore(level);
 }
 
-void __lwp_thread_resettimeslice()
+void __lwp_thread_resettimeslice(void)
 {
 	u32 level;
 	lwp_cntrl *exec;
@@ -363,7 +363,7 @@ void __lwp_thread_clearstate(lwp_cntrl *thethread,u32 state)
 	_CPU_ISR_Restore(level);
 }
 
-u32 __lwp_evaluatemode()
+u32 __lwp_evaluatemode(void)
 {
 	lwp_cntrl *exec;
 	
@@ -646,7 +646,7 @@ void __lwp_thread_close(lwp_cntrl *thethread)
 	__lwp_objmgr_free(thethread->object.information,&thethread->object);
 }
 
-void __lwp_thread_closeall()
+void __lwp_thread_closeall(void)
 {
 	u32 i,level;
 	lwp_queue *header;
@@ -696,7 +696,7 @@ u32 __lwp_thread_start(lwp_cntrl *thethread,void* (*entry)(void*),void *arg)
 	return 0;
 }
 
-void __lwp_thread_startmultitasking()
+void __lwp_thread_startmultitasking(void)
 {
 	_lwp_exitfunc = NULL;
 
@@ -724,7 +724,7 @@ void __lwp_thread_stopmultitasking(void (*exitfunc)())
 	}
 }
 
-void __lwp_thread_coreinit()
+void __lwp_thread_coreinit(void)
 {
 	u32 index;
 

--- a/libogc/lwp_threads.inl
+++ b/libogc/lwp_threads.inl
@@ -11,7 +11,7 @@ static __inline__ u32 __lwp_thread_isheir(lwp_cntrl *thethread)
 	return (thethread==_thr_heir);
 }
 
-static __inline__ void __lwp_thread_calcheir()
+static __inline__ void __lwp_thread_calcheir(void)
 {
 	_thr_heir = (lwp_cntrl*)_lwp_thr_ready[__lwp_priomap_highest()].first;
 #ifdef _LWPTHREADS_DEBUG
@@ -24,28 +24,28 @@ static __inline__ u32 __lwp_thread_isallocatedfp(lwp_cntrl *thethread)
 	return (thethread==_thr_allocated_fp);
 }
 
-static __inline__ void __lwp_thread_deallocatefp()
+static __inline__ void __lwp_thread_deallocatefp(void)
 {
 	_thr_allocated_fp = NULL;
 }
 
-static __inline__ void __lwp_thread_dispatchinitialize()
+static __inline__ void __lwp_thread_dispatchinitialize(void)
 {
 	_thread_dispatch_disable_level = 1;
 }
 
-static __inline__ void __lwp_thread_dispatchenable()
+static __inline__ void __lwp_thread_dispatchenable(void)
 {
 	if((--_thread_dispatch_disable_level)==0)
 		__thread_dispatch();
 }
 
-static __inline__ void __lwp_thread_dispatchdisable()
+static __inline__ void __lwp_thread_dispatchdisable(void)
 {
 	++_thread_dispatch_disable_level;
 }
 
-static __inline__ void __lwp_thread_dispatchunnest()
+static __inline__ void __lwp_thread_dispatchunnest(void)
 {
 	--_thread_dispatch_disable_level;
 }
@@ -55,7 +55,7 @@ static __inline__ void __lwp_thread_unblock(lwp_cntrl *thethread)
 	__lwp_thread_clearstate(thethread,LWP_STATES_BLOCKED);
 }
 
-static __inline__ void** __lwp_thread_getlibcreent()
+static __inline__ void** __lwp_thread_getlibcreent(void)
 {
 	return __lwp_thr_libc_reent;
 }
@@ -65,28 +65,28 @@ static __inline__ void __lwp_thread_setlibcreent(void **libc_reent)
 	__lwp_thr_libc_reent = libc_reent;
 }
 
-static __inline__ bool __lwp_thread_isswitchwant()
+static __inline__ bool __lwp_thread_isswitchwant(void)
 {
 
 	return _context_switch_want;
 }
 
-static __inline__ bool __lwp_thread_isdispatchenabled()
+static __inline__ bool __lwp_thread_isdispatchenabled(void)
 {
 	return (_thread_dispatch_disable_level==0);
 }
 
-static __inline__ void __lwp_thread_inittimeslice()
+static __inline__ void __lwp_thread_inittimeslice(void)
 {
 	__lwp_wd_initialize(&_lwp_wd_timeslice,__lwp_thread_tickle_timeslice,LWP_TIMESLICE_TIMER_ID,NULL);
 }
 
-static __inline__ void __lwp_thread_starttimeslice()
+static __inline__ void __lwp_thread_starttimeslice(void)
 {
 	__lwp_wd_insert_ticks(&_lwp_wd_timeslice,millisecs_to_ticks(1));
 }
 
-static __inline__ void __lwp_thread_stoptimeslice()
+static __inline__ void __lwp_thread_stoptimeslice(void)
 {
 	__lwp_wd_remove_ticks(&_lwp_wd_timeslice);
 }

--- a/libogc/lwp_watchdog.c
+++ b/libogc/lwp_watchdog.c
@@ -49,7 +49,7 @@ static void __lwp_wd_settimer(wd_cntrl *wd)
 	}
 }
 
-void __lwp_watchdog_init()
+void __lwp_watchdog_init(void)
 {
 	_wd_sync_level = 0;
 	_wd_sync_count = 0;

--- a/libogc/lwp_watchdog.inl
+++ b/libogc/lwp_watchdog.inl
@@ -54,7 +54,7 @@ static __inline__ u64 __lwp_wd_calc_ticks(const struct timespec *time)
 	return ticks;
 }
 
-static __inline__ void __lwp_wd_tickle_ticks()
+static __inline__ void __lwp_wd_tickle_ticks(void)
 {
 	__lwp_wd_tickle(&_wd_ticks_queue);
 }

--- a/libogc/lwp_wkspace.c
+++ b/libogc/lwp_wkspace.c
@@ -12,18 +12,18 @@ heap_cntrl __wkspace_heap;
 static heap_iblock __wkspace_iblock;
 static u32 __wkspace_heap_size = 0;
 
-u32 __lwp_wkspace_heapsize()
+u32 __lwp_wkspace_heapsize(void)
 {
 	return __wkspace_heap_size;
 }
 
-u32 __lwp_wkspace_heapfree()
+u32 __lwp_wkspace_heapfree(void)
 {
 	__lwp_heap_getinfo(&__wkspace_heap,&__wkspace_iblock);
 	return __wkspace_iblock.free_size;
 }
 
-u32 __lwp_wkspace_heapused()
+u32 __lwp_wkspace_heapused(void)
 {
 	__lwp_heap_getinfo(&__wkspace_heap,&__wkspace_iblock);
 	return __wkspace_iblock.used_size;

--- a/libogc/malloc_lock.c
+++ b/libogc/malloc_lock.c
@@ -16,7 +16,7 @@ extern int errno;
 static int initialized = 0;
 static lwp_mutex mem_lock;
 
-void __memlock_init()
+void __memlock_init(void)
 {
 	__lwp_thread_dispatchdisable();
 	if(!initialized) {

--- a/libogc/message.c
+++ b/libogc/message.c
@@ -52,7 +52,7 @@ typedef struct _mqbox_st
 
 lwp_objinfo _lwp_mqbox_objects;
 
-void __lwp_mqbox_init()
+void __lwp_mqbox_init(void)
 {
 	__lwp_objmgr_initinfo(&_lwp_mqbox_objects,LWP_MAX_MQUEUES,sizeof(mqbox_st));
 }
@@ -69,7 +69,7 @@ static __inline__ void __lwp_mqbox_free(mqbox_st *mqbox)
 	__lwp_objmgr_free(&_lwp_mqbox_objects,&mqbox->object);
 }
 
-static mqbox_st* __lwp_mqbox_allocate()
+static mqbox_st* __lwp_mqbox_allocate(void)
 {
 	mqbox_st *mqbox;
 

--- a/libogc/mutex.c
+++ b/libogc/mutex.c
@@ -66,7 +66,7 @@ static s32 __lwp_mutex_locksupp(mutex_t lock,u32 timeout,u8 block)
 	return _thr_executing->wait.ret_code;
 }
 
-void __lwp_mutex_init()
+void __lwp_mutex_init(void)
 {
 	__lwp_objmgr_initinfo(&_lwp_mutex_objects,LWP_MAX_MUTEXES,sizeof(mutex_st));
 }
@@ -84,7 +84,7 @@ static __inline__ void __lwp_mutex_free(mutex_st *lock)
 	__lwp_objmgr_free(&_lwp_mutex_objects,&lock->object);
 }
 
-static mutex_st* __lwp_mutex_allocate()
+static mutex_st* __lwp_mutex_allocate(void)
 {
 	mutex_st *lock;
 

--- a/libogc/network_wii.c
+++ b/libogc/network_wii.c
@@ -248,7 +248,7 @@ static char __kd_fs[] ATTRIBUTE_ALIGN(32) = "/dev/net/kd/request";
 
 #define ROUNDDOWN32(v)				(((u32)(v)-0x1f)&~0x1f)
 
-static s32 NetCreateHeap()
+static s32 NetCreateHeap(void)
 {
 	u32 level;
 	void *net_heap_ptr;
@@ -635,7 +635,7 @@ s32 net_get_status(void) {
 	return _last_init_result;
 }
 
-void net_deinit() {
+void net_deinit(void) {
 	if (_init_busy) {
 		debug_printf("aborting net_init_async\n");
 		_init_abort = true;
@@ -649,7 +649,7 @@ void net_deinit() {
 	_last_init_result = -ENETDOWN;
 }
 
-void net_wc24cleanup() {
+void net_wc24cleanup(void) {
     s32 kd_fd;
     STACK_ALIGN(u8, kd_buf, 0x20, 32);
 

--- a/libogc/pad.c
+++ b/libogc/pad.c
@@ -69,7 +69,7 @@ extern u32 __PADFixBits;
 
 static void __pad_enable(u32 chan);
 static void __pad_disable(u32 chan);
-static void __pad_doreset();
+static void __pad_doreset(void);
 static s32 __pad_onreset(s32 final);
 
 static sys_resetinfo pad_resetinfo = {
@@ -446,7 +446,7 @@ static void __pad_disable(u32 chan)
 	_CPU_ISR_Restore(level);
 }
 
-static void __pad_doreset()
+static void __pad_doreset(void)
 {
 	__pad_resettingchan = cntlzw(__pad_resettingbits);
 	if(__pad_resettingchan==32) return;
@@ -481,7 +481,7 @@ u32 __PADDisableRecalibration(s32 disable)
 	return ret;
 }
 
-u32 PAD_Init()
+u32 PAD_Init(void)
 {
 	u32 chan;
 	u16 prodpads = PAD_PRODPADS;
@@ -637,7 +637,7 @@ u32 PAD_Recalibrate(u32 mask)
 	return 1;
 }
 
-u32 PAD_Sync()
+u32 PAD_Sync(void)
 {
 	u32 ret = 0;
 
@@ -709,7 +709,7 @@ void PAD_Clamp(PADStatus *status)
 	}
 }
 
-u32 PAD_ScanPads()
+u32 PAD_ScanPads(void)
 {
 	s32 i;
 	u32 resetBits;

--- a/libogc/sdgecko_buf.c
+++ b/libogc/sdgecko_buf.c
@@ -17,7 +17,7 @@ typedef struct _buf_node {
 static BufNode s_buf[BUF_POOL_CNT];
 static BufNode *s_freepool;
 
-void sdgecko_initBufferPool()
+void sdgecko_initBufferPool(void)
 {
 	u32 i;
 #ifdef _POOLBUFFER_DEBUG
@@ -30,7 +30,7 @@ void sdgecko_initBufferPool()
 	s_freepool = s_buf;
 }
 
-u8*	sdgecko_allocBuffer()
+u8*	sdgecko_allocBuffer(void)
 {
 	u8 *buf = NULL;
 	

--- a/libogc/sdgecko_io.c
+++ b/libogc/sdgecko_io.c
@@ -88,7 +88,7 @@ static u16 _ioCrc16Table[256];
 static u32 _initType[MAX_DRIVE];
 static u32 _ioAddressingType[MAX_DRIVE];
 
-extern unsigned long gettick();
+extern unsigned long gettick(void);
 
 static __inline__ u32 __check_response(s32 drv_no,u8 res)
 {
@@ -107,7 +107,7 @@ static __inline__ u32 __check_response(s32 drv_no,u8 res)
 	return ((_ioError[drv_no]&CARDIO_OP_IOERR_FATAL)?CARDIO_ERROR_INTERNAL:CARDIO_ERROR_READY);
 }
 
-static void __init_crc7()
+static void __init_crc7(void)
 {
 	s32 i,j;
 	u8 c,crc7;
@@ -172,7 +172,7 @@ static u8 __make_crc7(void *buffer,u32 len)
 	return (res<<1)&0xff;
 }
 */
-static void __init_crc16()
+static void __init_crc16(void)
 {
 	s32 i,j;
 	u16 crc16,c;
@@ -1213,7 +1213,7 @@ static void __convert_sector(s32 drv_no,u32 sector_no,u8 *arg)
 	}
 }
 
-void sdgecko_initIODefault()
+void sdgecko_initIODefault(void)
 {
 	u32 i;
 #ifdef _CARDIO_DEBUG	

--- a/libogc/semaphore.c
+++ b/libogc/semaphore.c
@@ -54,7 +54,7 @@ typedef struct _sema_st
 
 lwp_objinfo _lwp_sema_objects;
 
-void __lwp_sema_init()
+void __lwp_sema_init(void)
 {
 	__lwp_objmgr_initinfo(&_lwp_sema_objects,LWP_MAX_SEMAS,sizeof(sema_st));
 }
@@ -71,7 +71,7 @@ static __inline__ void __lwp_sema_free(sema_st *sema)
 	__lwp_objmgr_free(&_lwp_sema_objects,&sema->object);
 }
 
-static sema_st* __lwp_sema_allocate()
+static sema_st* __lwp_sema_allocate(void)
 {
 	sema_st *sema;
 

--- a/libogc/si.c
+++ b/libogc/si.c
@@ -125,7 +125,7 @@ static vu16* const _viReg = (u16*)0xCC002000;
 
 static u32 __si_transfer(s32 chan,void *out,u32 out_len,void *in,u32 in_len,SICallback cb);
 
-static __inline__ struct _xy* __si_getxy()
+static __inline__ struct _xy* __si_getxy(void)
 {
 	switch(VIDEO_GetCurrentTvMode()) {
 		case VI_NTSC:
@@ -140,7 +140,7 @@ static __inline__ struct _xy* __si_getxy()
 	return NULL;
 }
 
-static __inline__ void __si_cleartcinterrupt()
+static __inline__ void __si_cleartcinterrupt(void)
 {
 	_siReg[13] = (_siReg[13]|SICOMCSR_TCINT)&SICOMCSR_TCINT;
 }
@@ -163,7 +163,7 @@ static void __si_alarmhandler(syswd_t thealarm,void *cbarg)
 	}
 }
 
-static u32 __si_completetransfer()
+static u32 __si_completetransfer(void)
 {
 	u32 val,sisr,cnt,i;
 	u32 *in;
@@ -408,7 +408,7 @@ static void __si_interrupthandler(u32 irq,void *ctx)
 	}
 }
 
-u32 SI_Sync()
+u32 SI_Sync(void)
 {
 	u32 level,ret;
 
@@ -422,7 +422,7 @@ u32 SI_Sync()
 	return ret;
 }
 
-u32 SI_Busy()
+u32 SI_Busy(void)
 {
 	return (sicntrl.chan==-1)?0:1;
 }
@@ -501,7 +501,7 @@ void SI_SetSamplingRate(u32 samplingrate)
 	_CPU_ISR_Restore(level);
 }
 
-void SI_RefreshSamplingRate()
+void SI_RefreshSamplingRate(void)
 {
 	SI_SetSamplingRate(sampling_rate);
 }
@@ -660,7 +660,7 @@ u32 SI_GetTypeAsync(s32 chan,SICallback cb)
 	return type;
 }
 
-void SI_TransferCommands()
+void SI_TransferCommands(void)
 {
 	_siReg[14] = 0x80000000;
 }
@@ -737,7 +737,7 @@ u32 SI_EnablePollingInterrupt(s32 enable)
 	return ret;
 }
 
-void __si_init()
+void __si_init(void)
 {
 	u32 i;
 #ifdef _SI_DEBUG

--- a/libogc/stm.c
+++ b/libogc/stm.c
@@ -69,15 +69,15 @@ static u32 __stm_immbufout[0x08] ATTRIBUTE_ALIGN(32) = {0,0,0,0,0,0,0,0};
 static char __stm_eh_fs[] ATTRIBUTE_ALIGN(32) = "/dev/stm/eventhook";
 static char __stm_imm_fs[] ATTRIBUTE_ALIGN(32) = "/dev/stm/immediate";
 
-s32 __STM_SetEventHook();
-s32 __STM_ReleaseEventHook();
+s32 __STM_SetEventHook(void);
+s32 __STM_ReleaseEventHook(void);
 static s32 __STMEventHandler(s32 result,void *usrdata);
 
 stmcallback __stm_eventcb = NULL;
 
 static vu16* const _viReg = (u16*)0xCC002000;
 
-s32 __STM_Init()
+s32 __STM_Init(void)
 {
 	if(__stm_initialized==1) return 1;
 #ifdef DEBUG_STM
@@ -100,7 +100,7 @@ s32 __STM_Init()
 	return 1;
 }
 
-s32 __STM_Close()
+s32 __STM_Close(void)
 {
 	s32 res;
 	s32 ret = 0;
@@ -120,7 +120,7 @@ s32 __STM_Close()
 	return ret;
 }
 
-s32 __STM_SetEventHook()
+s32 __STM_SetEventHook(void)
 {
 	s32 ret;
 	u32 level;
@@ -138,7 +138,7 @@ s32 __STM_SetEventHook()
 	return ret;
 }
 
-s32 __STM_ReleaseEventHook()
+s32 __STM_ReleaseEventHook(void)
 {
 	s32 ret;
 
@@ -186,7 +186,7 @@ stmcallback STM_RegisterEventHandler(stmcallback newhandler)
 	return old;
 }
 
-s32 STM_ShutdownToStandby()
+s32 STM_ShutdownToStandby(void)
 {
 	int res;
 	
@@ -207,7 +207,7 @@ s32 STM_ShutdownToStandby()
 	return res;
 }
 
-s32 STM_ShutdownToIdle()
+s32 STM_ShutdownToIdle(void)
 {
 	int res;
 	
@@ -254,7 +254,7 @@ s32 STM_SetLedMode(u32 mode)
 	return res;
 }
 
-s32 STM_RebootSystem()
+s32 STM_RebootSystem(void)
 {
 	int res;
 	

--- a/libogc/sys_state.inl
+++ b/libogc/sys_state.inl
@@ -1,7 +1,7 @@
 #ifndef __SYS_STATE_INL__
 #define __SYS_STATE_INL__
 
-static __inline__ void __sys_state_init()
+static __inline__ void __sys_state_init(void)
 {
 	_sys_state_curr = SYS_STATE_BEFORE_INIT;
 }
@@ -11,7 +11,7 @@ static __inline__ void __sys_state_set(u32 sys_state)
 	_sys_state_curr = sys_state;
 }
 
-static __inline__ u32 __sys_state_get()
+static __inline__ u32 __sys_state_get(void)
 {
 	return _sys_state_curr;
 }

--- a/libogc/system.c
+++ b/libogc/system.c
@@ -254,7 +254,7 @@ static __inline__ void __lwp_syswd_free(alarm_st *alarm)
 
 #ifdef HW_DOL
 #define SOFTRESET_ADR *((vu32*)0xCC003024)
-void __reload() { SOFTRESET_ADR=0; }
+void __reload(void) { SOFTRESET_ADR=0; }
 
 void __libogc_exit(int status)
 {
@@ -262,9 +262,9 @@ void __libogc_exit(int status)
 	__lwp_thread_stopmultitasking(__reload);
 }
 #else
-static void (*reload)() = (void(*)())0x80001800;
+static void (*reload)(void) = (void(*)(void))0x80001800;
 
-static bool __stub_found()
+static bool __stub_found(void)
 {
 	u64 sig = ((u64)(*(u32*)0x80001804) << 32) + *(u32*)0x80001808;
 	if (sig == 0x5354554248415858ULL) // 'STUBHAXX'
@@ -272,7 +272,7 @@ static bool __stub_found()
 	return false;
 }
 
-void __reload()
+void __reload(void)
 {
 	if(__stub_found()) {
 		__exception_closeall();
@@ -292,7 +292,7 @@ void __libogc_exit(int status)
 
 #endif
 
-static void __init_syscall_array() {
+static void __init_syscall_array(void) {
 	__syscalls.sbrk_r = __libogc_sbrk_r;
 	__syscalls.lock_init = __libogc_lock_init;
 	__syscalls.lock_close = __libogc_lock_close;
@@ -305,7 +305,7 @@ static void __init_syscall_array() {
 
 }
 
-static alarm_st* __lwp_syswd_allocate()
+static alarm_st* __lwp_syswd_allocate(void)
 {
 	alarm_st *alarm;
 
@@ -453,7 +453,7 @@ static void __STMEventHandler(u32 event)
 void * __attribute__ ((weak)) __myArena1Lo = 0;
 void * __attribute__ ((weak)) __myArena1Hi = 0;
 
-static void __lowmem_init()
+static void __lowmem_init(void)
 {
 	u32 *_gx = (u32*)__gxregs;
 
@@ -505,14 +505,14 @@ static void __lowmem_init()
 }
 
 #if defined(HW_RVL)
-static void __ipcbuffer_init()
+static void __ipcbuffer_init(void)
 {
 	__ipcbufferlo = (void*)__ipcbufferLo;
 	__ipcbufferhi = (void*)__ipcbufferHi;
 }
 #endif
 
-static void __memprotect_init()
+static void __memprotect_init(void)
 {
 	u32 level;
 
@@ -652,12 +652,12 @@ static s32 __sram_writecallback(s32 chn,s32 dev)
 	return 1;
 }
 
-static s32 __sram_sync()
+static s32 __sram_sync(void)
 {
 	return sramcntrl.sync;
 }
 
-void __sram_init()
+void __sram_init(void)
 {
 	sramcntrl.enabled = 0;
 	sramcntrl.locked = 0;
@@ -666,7 +666,7 @@ void __sram_init()
 	sramcntrl.offset = 64;
 }
 
-static void DisableWriteGatherPipe()
+static void DisableWriteGatherPipe(void)
 {
 	mtspr(920,(mfspr(920)&~0x40000000));
 }
@@ -757,7 +757,7 @@ static void __expand_font(const u8 *src,u8 *dest)
 	DCStoreRange(dest,sys_fontdata->sheet_fullsize);
 }
 
-static void __dsp_bootstrap()
+static void __dsp_bootstrap(void)
 {
 	u16 status;
 	u32 tick;
@@ -811,7 +811,7 @@ static void __dsp_bootstrap()
 #endif
 }
 
-static void __dsp_shutdown()
+static void __dsp_shutdown(void)
 {
 	u32 tick;
 
@@ -880,12 +880,12 @@ static void decode_szp(void *src,void *dest)
 	} while(cnt<size);
 }
 
-syssram* __SYS_LockSram()
+syssram* __SYS_LockSram(void)
 {
 	return (syssram*)__locksram(0);
 }
 
-syssramex* __SYS_LockSramEx()
+syssramex* __SYS_LockSramEx(void)
 {
 	return (syssramex*)__locksram(sizeof(syssram));
 }
@@ -900,7 +900,7 @@ u32 __SYS_UnlockSramEx(u32 write)
 	return __unlocksram(write,sizeof(syssram));
 }
 
-u32 __SYS_SyncSram()
+u32 __SYS_SyncSram(void)
 {
 	return __sram_sync();
 }
@@ -954,7 +954,7 @@ void __SYS_SetTime(s64 time)
 	_CPU_ISR_Restore(level);
 }
 
-s64 __SYS_GetSystemTime()
+s64 __SYS_GetSystemTime(void)
 {
 	u32 level;
 	s64 now;
@@ -967,7 +967,7 @@ s64 __SYS_GetSystemTime()
 	return now;
 }
 
-void __SYS_SetBootTime()
+void __SYS_SetBootTime(void)
 {
 	u32 gctime;
 
@@ -992,12 +992,12 @@ u32 __SYS_LoadFont(void *src,void *dest)
 }
 
 #if defined(HW_RVL)
-void* __SYS_GetIPCBufferLo()
+void* __SYS_GetIPCBufferLo(void)
 {
 	return __ipcbufferlo;
 }
 
-void* __SYS_GetIPCBufferHi()
+void* __SYS_GetIPCBufferHi(void)
 {
 	return __ipcbufferhi;
 }
@@ -1021,7 +1021,7 @@ void __SYS_DoPowerCB(void)
 }
 #endif
 
-void __SYS_InitCallbacks()
+void __SYS_InitCallbacks(void)
 {
 #if defined(HW_RVL)
 	__POWCallback = __POWDefaultHandler;
@@ -1030,12 +1030,12 @@ void __SYS_InitCallbacks()
 	__RSWCallback = __RSWDefaultHandler;
 }
 
-void __attribute__((weak)) __SYS_PreInit()
+void __attribute__((weak)) __SYS_PreInit(void)
 {
 
 }
 
-void SYS_Init()
+void SYS_Init(void)
 {
 	u32 level;
 
@@ -1096,7 +1096,7 @@ void SYS_Init()
 }
 
 // This function gets called inside the main thread, prior to the application's main() function
-void SYS_PreMain()
+void SYS_PreMain(void)
 {
 #if defined(HW_RVL)
 	u32 i;
@@ -1112,7 +1112,7 @@ void SYS_PreMain()
 #endif
 }
 
-u32 SYS_ResetButtonDown()
+u32 SYS_ResetButtonDown(void)
 {
 	return (!(_piReg[0]&0x00010000));
 }
@@ -1264,7 +1264,7 @@ void SYS_SetArena1Lo(void *newLo)
 	_CPU_ISR_Restore(level);
 }
 
-void* SYS_GetArena1Lo()
+void* SYS_GetArena1Lo(void)
 {
 	u32 level;
 	void *arenalo;
@@ -1285,7 +1285,7 @@ void SYS_SetArena1Hi(void *newHi)
 	_CPU_ISR_Restore(level);
 }
 
-void* SYS_GetArena1Hi()
+void* SYS_GetArena1Hi(void)
 {
 	u32 level;
 	void *arenahi;
@@ -1297,7 +1297,7 @@ void* SYS_GetArena1Hi()
 	return arenahi;
 }
 
-u32 SYS_GetArena1Size()
+u32 SYS_GetArena1Size(void)
 {
 	u32 level,size;
 
@@ -1331,7 +1331,7 @@ void SYS_SetArena2Lo(void *newLo)
 	_CPU_ISR_Restore(level);
 }
 
-void* SYS_GetArena2Lo()
+void* SYS_GetArena2Lo(void)
 {
 	u32 level;
 	void *arenalo;
@@ -1352,7 +1352,7 @@ void SYS_SetArena2Hi(void *newHi)
 	_CPU_ISR_Restore(level);
 }
 
-void* SYS_GetArena2Hi()
+void* SYS_GetArena2Hi(void)
 {
 	u32 level;
 	void *arenahi;
@@ -1364,7 +1364,7 @@ void* SYS_GetArena2Hi()
 	return arenahi;
 }
 
-u32 SYS_GetArena2Size()
+u32 SYS_GetArena2Size(void)
 {
 	u32 level,size;
 
@@ -1422,7 +1422,7 @@ void* SYS_AllocateFramebuffer(GXRModeObj *rmode)
 	return memalign(32, VIDEO_GetFrameBufferSize(rmode));
 }
 
-u32 SYS_GetFontEncoding()
+u32 SYS_GetFontEncoding(void)
 {
 	u32 ret,tv_mode;
 
@@ -1651,13 +1651,13 @@ void SYS_StartPMC(u32 mcr0val,u32 mcr1val)
 	mtmmcr1(mcr1val);
 }
 
-void SYS_StopPMC()
+void SYS_StopPMC(void)
 {
 	mtmmcr0(0);
 	mtmmcr1(0);
 }
 
-void SYS_ResetPMC()
+void SYS_ResetPMC(void)
 {
 	mtpmc1(0);
 	mtpmc2(0);
@@ -1665,7 +1665,7 @@ void SYS_ResetPMC()
 	mtpmc4(0);
 }
 
-void SYS_DumpPMC()
+void SYS_DumpPMC(void)
 {
 	printf("<%lu load/stores / %lu miss cycles / %lu cycles / %lu instructions>\n",mfpmc1(),mfpmc2(),mfpmc3(),mfpmc4());
 }
@@ -1697,7 +1697,7 @@ u32 SYS_GetWirelessID(u32 chan)
 }
 
 #if defined(HW_RVL)
-u32 SYS_GetHollywoodRevision()
+u32 SYS_GetHollywoodRevision(void)
 {
 	u32 rev;
 	DCInvalidateRange((void*)0x80003138,8);
@@ -1706,7 +1706,7 @@ u32 SYS_GetHollywoodRevision()
 }
 #endif
 
-u64 SYS_Time()
+u64 SYS_Time(void)
 {
 	u64 current_time = 0;
     u32 gmtime =0;

--- a/libogc/timesupp.c
+++ b/libogc/timesupp.c
@@ -18,7 +18,7 @@ static u32 exi_wait_inited = 0;
 static lwpq_t time_exi_wait;
 
 extern u32 __SYS_GetRTC(u32 *gctime);
-extern syssram* __SYS_LockSram();
+extern syssram* __SYS_LockSram(void);
 extern u32 __SYS_UnlockSram(u32 write);
 
 
@@ -108,7 +108,7 @@ u32 diff_nsec(u64 start,u64 end)
 	return ticks_to_nanosecs(diff);
 }
 
-void __timesystem_init()
+void __timesystem_init(void)
 {
 	if(!exi_wait_inited) {
 		exi_wait_inited = 1;
@@ -229,7 +229,7 @@ static s32 __time_exi_unlock(s32 chn,s32 dev)
 	return 1;
 }
 
-static void __time_exi_wait()
+static void __time_exi_wait(void)
 {
 	u32 ret;
 

--- a/libogc/usb.c
+++ b/libogc/usb.c
@@ -583,7 +583,7 @@ static u32 __find_next_endpoint(u8 *buffer,s32 size,u8 align)
 	return (buffer - ptr);
 }
 
-s32 USB_Initialize()
+s32 USB_Initialize(void)
 {
 	if(hId==-1) hId = iosCreateHeap(USB_HEAPSIZE);
 	if(hId<0) return IPC_ENOMEM;
@@ -648,7 +648,7 @@ mem_error:
 	return IPC_ENOMEM;
 }
 
-s32 USB_Deinitialize()
+s32 USB_Deinitialize(void)
 {
 	if (hid_host) {
 		if (hid_host->fd>=0) {

--- a/libogc/usbgecko.c
+++ b/libogc/usbgecko.c
@@ -24,7 +24,7 @@ static s32 __usbgecko_exi_unlock(s32 chan,s32 dev)
 	return 1;
 }
 
-static void __usbgecko_init()
+static void __usbgecko_init(void)
 {
 	u32 i;
 

--- a/libogc/usbmouse.c
+++ b/libogc/usbmouse.c
@@ -160,7 +160,7 @@ static void USBMouse_Close(void)
 
 //Search for a mouse connected to the wii usb port
 //Thanks to Sven Peter usbstorage support
-static s32 USBMouse_Open()
+static s32 USBMouse_Open(void)
 {
 	usb_device_entry *buffer;
 	u8 device_count, i;

--- a/libogc/usbstorage.c
+++ b/libogc/usbstorage.c
@@ -197,7 +197,7 @@ static s32 __USB_CtrlMsgTimeout(usbstorage_handle *dev, u8 bmRequestType, u8 bmR
 static u8 *arena_ptr=NULL;
 static u8 *cbw_buffer=NULL;
 
-s32 USBStorage_Initialize()
+s32 USBStorage_Initialize(void)
 {
 	u32 level;
 
@@ -666,7 +666,7 @@ s32 USBStorage_ReadCapacity(usbstorage_handle *dev, u8 lun, u32 *sector_size, u3
 	return retval;
 }
 
-s32 USBStorage_IsDVD()
+s32 USBStorage_IsDVD(void)
 {
 	u32 sectorsize, numSectors;
 
@@ -957,7 +957,7 @@ static bool __usbstorage_Shutdown(void)
 	return true;
 }
 
-void USBStorage_Deinitialize()
+void USBStorage_Deinitialize(void)
 {
 	__usbstorage_Shutdown();
 	LWP_CloseQueue(__usbstorage_waitq);

--- a/libogc/video.c
+++ b/libogc/video.c
@@ -1359,7 +1359,7 @@ static VIPositionCallback positionCB = NULL;
 
 static vu16* const _viReg = (u16*)0xCC002000;
 
-extern syssram* __SYS_LockSram();
+extern syssram* __SYS_LockSram(void);
 extern u32 __SYS_UnlockSram(u32 write);
 
 extern void __VIClearFramebuffer(void*,u32,u32);
@@ -1370,7 +1370,7 @@ extern void udelay(int us);
 static u32 messages$128 = 0;
 static u32 printregs = 1;
 
-static void printRegs()
+static void printRegs(void)
 {
 	if(!printregs) {
 		printf("displayOffsetH = %d\ndisplayOffsetV = %d\n",displayOffsetH,displayOffsetV);
@@ -1397,7 +1397,7 @@ static void printRegs()
 	}
 }
 
-static void printDebugCalculations()
+static void printDebugCalculations(void)
 {
 	if(!messages$128) {
 		messages$128 = 1;
@@ -1515,12 +1515,12 @@ static inline u32 __viSetSDA(u32 channel)
 	return 1;
 }
 
-static inline u32 __viGetSDA()
+static inline u32 __viGetSDA(void)
 {
 	return _SHIFTR(_i2cReg[50],15,1);
 }
 
-static inline void __viCheckI2C()
+static inline void __viCheckI2C(void)
 {
 	__viOpenI2C(0);
 	udelay(4);
@@ -1790,7 +1790,7 @@ static inline void __adjustPosition(u16 acv)
 	HorVer.adjustedPanSizeY = HorVer.panSizeY+(dispPosY/fact)-(dispSizeY/fact);
 }
 
-static inline void __importAdjustingValues()
+static inline void __importAdjustingValues(void)
 {
 #ifdef HW_DOL
 	syssram *sram;
@@ -2051,7 +2051,7 @@ static inline void __getCurrentDisplayPosition(u32 *px,u32 *py)
 	*py = vpos;
 }
 
-static inline u32 __getCurrentHalfLine()
+static inline u32 __getCurrentHalfLine(void)
 {
 	u32 vpos = 0;
 	u32 hpos = 0;
@@ -2065,7 +2065,7 @@ static inline u32 __getCurrentHalfLine()
 	return vpos+(hpos/currTiming->hlw);
 }
 
-static inline u32 __getCurrentFieldEvenOdd()
+static inline u32 __getCurrentFieldEvenOdd(void)
 {
 	u32 hline;
 
@@ -2075,7 +2075,7 @@ static inline u32 __getCurrentFieldEvenOdd()
 	return 0;
 }
 
-static inline u32 __VISetRegs()
+static inline u32 __VISetRegs(void)
 {
 	u32 val;
 	u64 mask;
@@ -2247,17 +2247,17 @@ static void __VIRetraceHandler(u32 nIrq,void *pCtx)
 	LWP_ThreadBroadcast(video_queue);
 }
 
-void* VIDEO_GetNextFramebuffer()
+void* VIDEO_GetNextFramebuffer(void)
 {
 	return nextFb;
 }
 
-void* VIDEO_GetCurrentFramebuffer()
+void* VIDEO_GetCurrentFramebuffer(void)
 {
 	return currentFb;
 }
 
-void VIDEO_Init()
+void VIDEO_Init(void)
 {
 	u32 level,vimode = 0;
 
@@ -2479,7 +2479,7 @@ void VIDEO_SetNextRightFramebuffer(void *fb)
 	_CPU_ISR_Restore(level);
 }
 
-void VIDEO_Flush()
+void VIDEO_Flush(void)
 {
 	u32 level;
 	u32 val;
@@ -2516,7 +2516,7 @@ void VIDEO_SetBlack(bool black)
 	_CPU_ISR_Restore(level);
 }
 
-u32 VIDEO_GetNextField()
+u32 VIDEO_GetNextField(void)
 {
 	u32 level,nextfield;
 
@@ -2527,7 +2527,7 @@ u32 VIDEO_GetNextField()
 	return nextfield^(HorVer.adjustedDispPosY&0x0001);	//if the YOrigin is at an odd position we've to swap it again, since the Fb registers are set swapped if this rule applies
 }
 
-u32 VIDEO_GetCurrentTvMode()
+u32 VIDEO_GetCurrentTvMode(void)
 {
 	u32 mode;
 	u32 level;
@@ -2632,7 +2632,7 @@ GXRModeObj *rmode = NULL;
 
 }
 
-u32 VIDEO_GetCurrentLine()
+u32 VIDEO_GetCurrentLine(void)
 {
 	u32 level,curr_hl = 0;
 

--- a/libogc/wiisd.c
+++ b/libogc/wiisd.c
@@ -196,7 +196,7 @@ static s32 __sdio_setclock(u32 set)
  
 	return ret;
 }
-static s32 __sdio_getstatus()
+static s32 __sdio_getstatus(void)
 {
 	s32 ret;
 	STACK_ALIGN(u32,status,1,32);
@@ -207,7 +207,7 @@ static s32 __sdio_getstatus()
 	return *status;
 }
  
-static s32 __sdio_resetcard()
+static s32 __sdio_resetcard(void)
 {
 	s32 ret;
  	STACK_ALIGN(u32,status,1,32);
@@ -293,7 +293,7 @@ static s32 __sdio_setbuswidth(u32 bus_width)
 }
 
 #if 0
-static s32 __sd0_getstatus()
+static s32 __sd0_getstatus(void)
 {
 	s32 ret;
 	u32 status = 0;
@@ -305,7 +305,7 @@ static s32 __sd0_getstatus()
 }
 #endif
 
-static s32 __sd0_getrca()
+static s32 __sd0_getrca(void)
 {
 	s32 ret;
 	u32 rca;
@@ -317,7 +317,7 @@ static s32 __sd0_getrca()
 	return (rca&0xffff);
 }
  
-static s32 __sd0_select()
+static s32 __sd0_select(void)
 {
 	s32 ret;
  
@@ -326,7 +326,7 @@ static s32 __sd0_select()
 	return ret;
 }
  
-static s32 __sd0_deselect()
+static s32 __sd0_deselect(void)
 {
 	s32 ret;
  
@@ -361,7 +361,7 @@ static s32 __sd0_setbuswidth(u32 bus_width)
 }
 
 #if 0
-static s32 __sd0_getcsd()
+static s32 __sd0_getcsd(void)
 {
 	s32 ret;
  
@@ -371,7 +371,7 @@ static s32 __sd0_getcsd()
 }
 #endif
 
-static s32 __sd0_getcid()
+static s32 __sd0_getcid(void)
 {
 	s32 ret;
  
@@ -381,7 +381,7 @@ static s32 __sd0_getcid()
 }
 
 
-static	bool __sd0_initio()
+static	bool __sd0_initio(void)
 {
 	s32 ret;
 	s32 tries;
@@ -500,7 +500,7 @@ static	bool __sd0_initio()
 	return false;
 }
 
-bool sdio_Deinitialize()
+bool sdio_Deinitialize(void)
 {
 	if(__sd0_fd>=0)
 		IOS_Close(__sd0_fd);
@@ -510,7 +510,7 @@ bool sdio_Deinitialize()
 	return true;
 }
 
-bool sdio_Startup()
+bool sdio_Startup(void)
 {
 	if(__sdio_initialized==1) return true;
  
@@ -539,7 +539,7 @@ bool sdio_Startup()
  
  
  
-bool sdio_Shutdown()
+bool sdio_Shutdown(void)
 {
 	if(__sd0_initialized==0) return false;
 
@@ -625,18 +625,18 @@ bool sdio_WriteSectors(sec_t sector, sec_t numSectors,const void* buffer)
 	return (ret>=0);
 }
  
-bool sdio_ClearStatus()
+bool sdio_ClearStatus(void)
 {
 	return true;
 }
  
-bool sdio_IsInserted()
+bool sdio_IsInserted(void)
 {
 	return ((__sdio_getstatus() & SDIO_STATUS_CARD_INSERTED) ==
 			SDIO_STATUS_CARD_INSERTED);
 }
 
-bool sdio_IsInitialized()
+bool sdio_IsInitialized(void)
 {
 	return ((__sdio_getstatus() & SDIO_STATUS_CARD_INITIALIZED) ==
 			SDIO_STATUS_CARD_INITIALIZED);


### PR DESCRIPTION
Simply adds missing `void` in parameter lists where applicable to make them well-formed prototypes (which should also eliminate quite a lot of warnings under the `-Wmissing-prototypes` flag). The only prototypes I haven't touched are the exception handler ones and IRQ related ones. I'll save those for a different PR, since they require different changes.

Note that this doesn't touch any of the libs outside of libogc itself.