### PR TITLE
Amend prototypes for exception handlers and interrupt handlers/callbacks

### DIFF
--- a/gc/ogc/system.h
+++ b/gc/ogc/system.h
@@ -219,8 +219,8 @@ struct _sys_fontheader {
     u8  c3;
 } ATTRIBUTE_PACKED;
 
-typedef void (*resetcallback)();
-typedef void (*powercallback)();
+typedef void (*resetcallback)(u32 irq, void* ctx);
+typedef void (*powercallback)(void);
 typedef s32 (*resetfunction)(s32 final);
 typedef struct _sys_resetinfo sys_resetinfo;
 

--- a/libogc/exception.c
+++ b/libogc/exception.c
@@ -64,10 +64,10 @@ static int reload_timer = -1;
 void __exception_sethandler(u32 nExcept, void (*pHndl)(frame_context*));
 
 extern void udelay(int us);
-extern void fpu_exceptionhandler();
-extern void irq_exceptionhandler();
-extern void dec_exceptionhandler();
-extern void default_exceptionhandler();
+extern void fpu_exceptionhandler(frame_context*);
+extern void irq_exceptionhandler(frame_context*);
+extern void dec_exceptionhandler(frame_context*);
+extern void default_exceptionhandler(frame_context*);
 extern void VIDEO_SetFramebuffer(void *);
 extern void __reload(void);
 

--- a/libogc/system.c
+++ b/libogc/system.c
@@ -136,10 +136,10 @@ static void *__ipcbufferlo = NULL;
 static void *__ipcbufferhi = NULL;
 #endif
 
-static void __RSWDefaultHandler();
+static void __RSWDefaultHandler(u32 irq, void* ctx);
 static resetcallback __RSWCallback = NULL;
 #if defined(HW_RVL)
-static void __POWDefaultHandler();
+static void __POWDefaultHandler(void);
 static powercallback __POWCallback = NULL;
 
 static u32 __sys_resetdown = 0;
@@ -387,24 +387,24 @@ static void __doreboot(u32 resetcode,s32 force_menu)
 }
 #endif
 
-static void __MEMInterruptHandler()
+static void __MEMInterruptHandler(u32 irq, void* ctx)
 {
 	_memReg[16] = 0;
 }
 
-static void __RSWDefaultHandler()
+static void __RSWDefaultHandler(u32 irq, void* ctx)
 {
 
 }
 
 #if defined(HW_RVL)
-static void __POWDefaultHandler()
+static void __POWDefaultHandler(void)
 {
 }
 #endif
 
 #if defined(HW_DOL)
-static void __RSWHandler()
+static void __RSWHandler(u32 irq, void* ctx)
 {
 	s64 now;
 	static s64 hold_down = 0;
@@ -419,7 +419,7 @@ static void __RSWHandler()
 		__MaskIrq(IRQMASK(IRQ_PI_RSW));
 
 		if(__RSWCallback) {
-			__RSWCallback();
+			__RSWCallback(irq, ctx);
 		}
 	}
 	_piReg[0] = 2;
@@ -437,7 +437,7 @@ static void __STMEventHandler(u32 event)
 		if(ret) {
 			_CPU_ISR_Disable(level);
 			__sys_resetdown = 1;
-			__RSWCallback();
+			__RSWCallback(IRQ_PI_RSW, NULL);
 			_CPU_ISR_Restore(level);
 		}
 	}

--- a/libogc/system.c
+++ b/libogc/system.c
@@ -437,7 +437,9 @@ static void __STMEventHandler(u32 event)
 		if(ret) {
 			_CPU_ISR_Disable(level);
 			__sys_resetdown = 1;
-			__RSWCallback(IRQ_PI_RSW, NULL);
+			if(__RSWCallback) {
+				__RSWCallback(IRQ_PI_RSW, NULL);
+			}
 			_CPU_ISR_Restore(level);
 		}
 	}


### PR DESCRIPTION
`__exception_sethandler()` expects handler functions taking a `frame_context*`, and `IRQ_Request` expects functions taking a `u32` signifying an IRQ and a `void*` for passing along any extra contextual data.