### PR TITLE
asndlib/aesndlib: Amend prototypes for functions with no arguments

### DIFF
--- a/gc/aesndlib.h
+++ b/gc/aesndlib.h
@@ -34,11 +34,11 @@ typedef struct aesndpb_t AESNDPB;
 typedef void (*AESNDVoiceCallback)(AESNDPB *pb,u32 state);
 typedef void (*AESNDAudioCallback)(void *audio_buffer,u32 len);
 
-void AESND_Init();
-void AESND_Reset();
+void AESND_Init(void);
+void AESND_Reset(void);
 void AESND_Pause(bool pause);
-u32 AESND_GetDSPProcessTime();
-f32 AESND_GetDSPProcessUsage();
+u32 AESND_GetDSPProcessTime(void);
+f32 AESND_GetDSPProcessUsage(void);
 AESNDAudioCallback AESND_RegisterAudioCallback(AESNDAudioCallback cb);
 
 AESNDPB* AESND_AllocateVoice(AESNDVoiceCallback cb);

--- a/gc/asndlib.h
+++ b/gc/asndlib.h
@@ -197,11 +197,11 @@ int ANote2Freq(int note, int freq_base,int note_base);
 
 /*! \brief Initializes the ASND lib and fixes the hardware sample rate to 48000.
  * \return None. */
-void ASND_Init();
+void ASND_Init(void);
 
 /*! \brief De-initializes the ASND lib.
  * \return None. */
-void ASND_End();
+void ASND_End(void);
 
 /*! \brief Used to pause (or unpause) the sound.
  * \note The sound starts paused when ASND_Init() is called.
@@ -211,22 +211,22 @@ void ASND_Pause(s32 paused);
 
 /*! \brief Returns sound paused status.
  * \return 1 if paused, 0 if unpaused. */
-s32 ASND_Is_Paused();
+s32 ASND_Is_Paused(void);
 
 /*! \brief Returns the global time.
  * \details The time is updated from the IRQ.
  * \return The current time, in milliseconds. */
-u32 ASND_GetTime();
+u32 ASND_GetTime(void);
 
 /*! \brief Retrieves the global sample counter.
  * \details This counter is updated from the IRQ in steps of ASND_GetSamplesPerTick().
  * \note You can use this to implement one timer with high precision.
  * \return Current sample. */
-u32 ASND_GetSampleCounter();
+u32 ASND_GetSampleCounter(void);
 
 /*! \brief Retrieves the samples sent from the IRQ in one tick.
  * \return Samples per tick. */
-u32 ASND_GetSamplesPerTick();
+u32 ASND_GetSamplesPerTick(void);
 
 /*! \brief Set the global time.
  * \details This time is updated from the IRQ.
@@ -238,12 +238,12 @@ void ASND_SetTime(u32 time);
  * \details This callback is called from the IRQ.
  * \param[in] callback Callback function to assign.
  * \return None. */
-void ASND_SetCallback(void (*callback)());
+void ASND_SetCallback(void (*callback)(void));
 
 /*! \brief Returns the current audio rate.
  * \note This function is implemented for compatibility with SNDLIB.
  * \return Audio rate (48000). */
-s32 ASND_GetAudioRate();
+s32 ASND_GetAudioRate(void);
 
 /*! @} */
 
@@ -310,7 +310,7 @@ s32 ASND_StatusVoice(s32 voice);
  * \note Voice 0 is the last possible voice that can be returned. The idea is that this voice is reserved for a MOD/OGG/MP3/etc. player. With this in mind,
  * you can use this function to determine that the rest of the voices are working if the return value is < 1.
  * \return SND_INVALID or the first free voice from 0 to (MAX_SND_VOICES-1). */
-s32 ASND_GetFirstUnusedVoice();
+s32 ASND_GetFirstUnusedVoice(void);
 
 /*! \brief Changes the voice pitch in real-time.
  * \details This function can be used to create audio effects such as Doppler effect emulation.
@@ -369,9 +369,9 @@ s32 ASND_TestVoiceBufferReady(s32 voice);
 /*! \brief Returns the DSP usage.
  * \details The value is a percentage of DSP usage.
  * \return DSP usage, in percent. */
-u32 ASND_GetDSP_PercentUse();
+u32 ASND_GetDSP_PercentUse(void);
 
-u32 ASND_GetDSP_ProcessTime();
+u32 ASND_GetDSP_ProcessTime(void);
 
 /*! @} */
 

--- a/libaesnd/aesndlib.c
+++ b/libaesnd/aesndlib.c
@@ -359,7 +359,7 @@ static void __dsp_donecallback(dsptask_t *task)
 	__aesnddspabrequested = 0;
 }
 
-static void __audio_dma_callback()
+static void __audio_dma_callback(void)
 {
 	void *ptr;
 
@@ -415,7 +415,7 @@ static void __aesndloaddsptask(dsptask_t *task,const void *dsp_code,u32 dsp_code
 	DSP_AddTask(task);
 }
 
-void AESND_Init()
+void AESND_Init(void)
 {
 	u32 i,level;
 
@@ -461,7 +461,7 @@ void AESND_Init()
 	_CPU_ISR_Restore(level);
 }
 
-void AESND_Reset()
+void AESND_Reset(void)
 {
 	u32 level;
 
@@ -491,7 +491,7 @@ void AESND_Pause(bool pause)
 	_CPU_ISR_Restore(level);
 }
 
-u32 AESND_GetDSPProcessTime()
+u32 AESND_GetDSPProcessTime(void)
 {
 	u32 level;
 	u32 time = 0;
@@ -503,7 +503,7 @@ u32 AESND_GetDSPProcessTime()
 	return time;
 }
 
-f32 AESND_GetDSPProcessUsage()
+f32 AESND_GetDSPProcessUsage(void)
 {
 	u32 level;
 	f32 usage = 0.0f;

--- a/libasnd/asndlib.c
+++ b/libasnd/asndlib.c
@@ -94,7 +94,7 @@ static vs32 global_pause = 1;
 static vu32 global_counter = 0;
 
 static vu32 DSP_DI_HANDLER = 1;
-static void (*global_callback)()=NULL;
+static void (*global_callback)(void) = NULL;
 
 static u32 asnd_inited = 0;
 static t_sound_data sound_data[MAX_SND_VOICES];
@@ -257,7 +257,7 @@ static void __dsp_donecallback(dsptask_t *task)
 	dsp_done = 1;
 }
 
-static void audio_dma_callback()
+static void audio_dma_callback(void)
 {
 	u32 n;
 
@@ -348,7 +348,7 @@ static void audio_dma_callback()
 	}
 }
 
-void ASND_Init()
+void ASND_Init(void)
 {
 	u32 i,level;
 
@@ -396,7 +396,7 @@ void ASND_Init()
 
 /*------------------------------------------------------------------------------------------------------------------------------------------------------*/
 
-void ASND_End()
+void ASND_End(void)
 {
    if(asnd_inited) {
        AUDIO_StopDMA();
@@ -702,28 +702,28 @@ void ASND_Pause(s32 pause)
 
 /*------------------------------------------------------------------------------------------------------------------------------------------------------*/
 
-s32 ASND_Is_Paused()
+s32 ASND_Is_Paused(void)
 {
 	return global_pause;
 }
 
 /*------------------------------------------------------------------------------------------------------------------------------------------------------*/
 
-u32 ASND_GetTime()
+u32 ASND_GetTime(void)
 {
 	return (global_counter * SND_BUFFERSIZE/4)/48;
 }
 
 /*------------------------------------------------------------------------------------------------------------------------------------------------------*/
 
-u32 ASND_GetSampleCounter()
+u32 ASND_GetSampleCounter(void)
 {
 	return (global_counter * SND_BUFFERSIZE/4);
 }
 
 /*------------------------------------------------------------------------------------------------------------------------------------------------------*/
 
-u32 ASND_GetSamplesPerTick()
+u32 ASND_GetSamplesPerTick(void)
 {
 	return (SND_BUFFERSIZE/4);
 }
@@ -737,21 +737,21 @@ void ASND_SetTime(u32 time)
 
 /*------------------------------------------------------------------------------------------------------------------------------------------------------*/
 
-void ASND_SetCallback(void (*callback)())
+void ASND_SetCallback(void (*callback)(void))
 {
 	global_callback=callback;
 }
 
 /*------------------------------------------------------------------------------------------------------------------------------------------------------*/
 
-s32 ASND_GetAudioRate()
+s32 ASND_GetAudioRate(void)
 {
 	return 48000;
 }
 
 /*------------------------------------------------------------------------------------------------------------------------------------------------------*/
 
-s32 ASND_GetFirstUnusedVoice()
+s32 ASND_GetFirstUnusedVoice(void)
 {
 
 	s32 n;
@@ -785,12 +785,12 @@ s32 ASND_ChangePitchVoice(s32 voice, s32 pitch)
 
 /*------------------------------------------------------------------------------------------------------------------------------------------------------*/
 
-u32 ASND_GetDSP_PercentUse()
+u32 ASND_GetDSP_PercentUse(void)
 {
 	return (time_of_process)*100/21333; // time_of_process = nanoseconds , 1024 samples= 21333 nanoseconds
 }
 
-u32 ASND_GetDSP_ProcessTime()
+u32 ASND_GetDSP_ProcessTime(void)
 {
 	u32 level,ret;
 


### PR DESCRIPTION
Fairly trivial correctness stuff that squashes more missing prototype warnings.