### PR TITLE
libdi: Amend prototypes for functions with no arguments

### DIFF
--- a/gc/di/di.h
+++ b/gc/di/di.h
@@ -90,24 +90,24 @@ typedef int(*read_func_async)(void*,uint32_t,uint32_t,ipccallback);
 extern int di_fd;
 extern const DISC_INTERFACE __io_wiidvd;
 
-int DI_Init();
+int DI_Init(void);
 void DI_LoadDVDX(bool load);
 void DI_UseCache(bool use);
 void DI_SetInitCallback(di_callback cb);
-void DI_Mount();
-void DI_Close();
-int DI_GetStatus();
+void DI_Mount(void);
+void DI_Close(void);
+int DI_GetStatus(void);
 
 int DI_Identify(DI_DriveID* id);
-int DI_CheckDVDSupport();
+int DI_CheckDVDSupport(void);
 int DI_ReadDiscID(u64 *id);
 int DI_GetError(uint32_t* error);
 int DI_GetCoverRegister(uint32_t* status);
-int DI_Reset();
+int DI_Reset(void);
 
-int DI_StopMotor();
-int DI_Eject();
-int DI_KillDrive();
+int DI_StopMotor(void);
+int DI_Eject(void);
+int DI_KillDrive(void);
 
 int DI_ReadDVD(void* buf, uint32_t len, uint32_t lba);
 int DI_ReadDVDAsync(void* buf, uint32_t len, uint32_t lba, ipccallback ipc_cb);

--- a/libdi/di.c
+++ b/libdi/di.c
@@ -196,7 +196,7 @@ typedef struct
 } cache_page;
 static cache_page *cache_read = NULL;
 
-static void CreateDVDCache()
+static void CreateDVDCache(void)
 {
 	if (cache_read != NULL)
 		return;
@@ -252,7 +252,7 @@ u32 __di_check_ahbprot(void) {
 	return ((*(vu32*)0xcd800064 == 0xFFFFFFFF) ? 1 : 0);
 }
 
-int DI_Init() {
+int DI_Init(void) {
 	if(di_fd >= 0)
 		return 1;
 
@@ -285,7 +285,7 @@ void DI_UseCache(bool use) {
 	use_dvd_cache = use;
 }
 
-void DI_Mount() {
+void DI_Mount(void) {
 	if(di_fd < 0)
 		return;
 
@@ -308,7 +308,7 @@ void DI_Mount() {
 		cache_read->block = CACHE_FREE; // reset cache
 }
 
-void DI_Close(){
+void DI_Close(void) {
 	if(di_fd < 0)
 		return;
 
@@ -444,7 +444,7 @@ static s32 _cover_callback(s32 ret, void* usrdata){
 }
 
 /* Get current status, will return the API status */
-int DI_GetStatus(){
+int DI_GetStatus(void) {
 	return state;
 }
 
@@ -477,7 +477,7 @@ int DI_Identify(DI_DriveID* id){
 	return (ret == 1)? 0 : -ret;
 }
 
-int DI_CheckDVDSupport() {
+int DI_CheckDVDSupport(void) {
 	DI_DriveID id;
 
 	if(DI_Identify(&id) == 0 && id.rel_date <= 0x20080714)
@@ -515,7 +515,7 @@ int DI_GetError(uint32_t* error){
 /*
 Reset the drive.
 */
-int DI_Reset(){
+int DI_Reset(void) {
 	if(di_fd < 0)
 		return -ENXIO;
 
@@ -765,12 +765,12 @@ static int _DI_SetMotor(int flag){
 }
 
 /* Stop the drives motor */
-int DI_StopMotor(){
+int DI_StopMotor(void) {
 	return _DI_SetMotor(0);
 }
 
 /* Stop the motor, and eject the disc. Also needs a reset afterwards for normal operation */
-int DI_Eject(){
+int DI_Eject(void) {
 	return _DI_SetMotor(1);
 }
 
@@ -780,11 +780,11 @@ will not take in or eject the disc. Your drive will be d - e - d, dead.
 I deem this function to be harmless, as normal operation will resume after a reset.
 However, I am not liable for anyones drive exploding as a result from using this function.
 */
-int DI_KillDrive(){
+int DI_KillDrive(void) {
 	return _DI_SetMotor(2);
 }
 
-int DI_ClosePartition() {
+int DI_ClosePartition(void) {
 	if(di_fd < 0)
 		return -ENXIO;
 
@@ -913,7 +913,7 @@ int DI_ReadDiscID(uint64_t *id)
 	return(ret == 1)? 0 : -ret;
 }
 
-static bool diio_Startup()
+static bool diio_Startup(void)
 {
 	u64 t1,t2;
 
@@ -937,7 +937,7 @@ static bool diio_Startup()
 	return false;
 }
 
-static bool diio_IsInserted()
+static bool diio_IsInserted(void)
 {
 	u32 val;
 
@@ -963,12 +963,12 @@ static bool diio_WriteSectors(sec_t sector,sec_t numSectors,const void *buffer)
 	return true;
 }
 
-static bool diio_ClearStatus()
+static bool diio_ClearStatus(void)
 {
 	return true;
 }
 
-static bool diio_Shutdown()
+static bool diio_Shutdown(void)
 {
 	DI_StopMotor();
 	return true;

--- a/libdi/di.c
+++ b/libdi/di.c
@@ -977,10 +977,10 @@ static bool diio_Shutdown(void)
 const DISC_INTERFACE __io_wiidvd = {
 	DEVICE_TYPE_WII_DVD,
 	FEATURE_MEDIUM_CANREAD | FEATURE_WII_DVD,
-	(FN_MEDIUM_STARTUP)&diio_Startup,
-	(FN_MEDIUM_ISINSERTED)&diio_IsInserted,
-	(FN_MEDIUM_READSECTORS)&diio_ReadSectors,
-	(FN_MEDIUM_WRITESECTORS)&diio_WriteSectors,
-	(FN_MEDIUM_CLEARSTATUS)&diio_ClearStatus,
-	(FN_MEDIUM_SHUTDOWN)&diio_Shutdown
+	diio_Startup,
+	diio_IsInserted,
+	diio_ReadSectors,
+	diio_WriteSectors,
+	diio_ClearStatus,
+	diio_Shutdown
 };


### PR DESCRIPTION
This also allows getting rid of casts that would otherwise hide bugs if the `DISC_INTERFACE` functions ever change in the future (unlikely, but still always nice to allow the compiler to point out any issues if it does).