### PR TITLE
lwbt: Amend prototypes that take no arguments

### DIFF
--- a/gc/bte/bte.h
+++ b/gc/bte/bte.h
@@ -118,8 +118,8 @@ struct bte_pcb
 
 typedef s32 (*btecallback)(s32 result,void *userdata);
 
-void BTE_Init();
-void BTE_Shutdown();
+void BTE_Init(void);
+void BTE_Shutdown(void);
 s32 BTE_InitCore(btecallback cb);
 s32 BTE_ApplyPatch(btecallback cb);
 s32 BTE_InitSub(btecallback cb);
@@ -127,7 +127,7 @@ s32 BTE_ReadStoredLinkKey(struct linkkey_info *keys,u8 max_cnt,btecallback cb);
 s32 BTE_ReadBdAddr(struct bd_addr *bdaddr, btecallback cb);
 void (*BTE_SetDisconnectCallback(void (*callback)(struct bd_addr *bdaddr,u8 reason)))(struct bd_addr *bdaddr,u8 reason);
 
-struct bte_pcb* bte_new();
+struct bte_pcb* bte_new(void);
 void bte_arg(struct bte_pcb *pcb,void *arg);
 void bte_received(struct bte_pcb *pcb, s32 (*recv)(void *arg,void *buffer,u16 len));
 void bte_disconnected(struct bte_pcb *pcb,s32 (disconn_cfm)(void *arg,struct bte_pcb *pcb,u8 err));

--- a/lwbt/bte.c
+++ b/lwbt/bte.c
@@ -363,7 +363,7 @@ static err_t bte_process_input(void *arg,struct l2cap_pcb *pcb,struct pbuf *p,er
 	return ERR_OK;
 }
 
-void BTE_Init()
+void BTE_Init(void)
 {
 	u32 level;
 	struct timespec tb;
@@ -394,7 +394,7 @@ void BTE_Init()
 	SYS_SetPeriodicAlarm(btstate.timer_svc,&tb,&tb,bt_alarmhandler, NULL);
 }
 
-void BTE_Shutdown()
+void BTE_Shutdown(void)
 {
 	u32 level;
 
@@ -503,7 +503,7 @@ void (*BTE_SetDisconnectCallback(void (*callback)(struct bd_addr *bdaddr,u8 reas
 	return l2cap_disconnect_bb(callback);
 }
 
-struct bte_pcb* bte_new()
+struct bte_pcb* bte_new(void)
 {
 	struct bte_pcb *pcb;
 

--- a/lwbt/btmemr.c
+++ b/lwbt/btmemr.c
@@ -40,7 +40,7 @@ static void plug_holes(struct mem *rmem)
 	}
 }
 
-void btmemr_init()
+void btmemr_init(void)
 {
 	u32 level;
 	struct mem *rmem;

--- a/lwbt/btmemr.h
+++ b/lwbt/btmemr.h
@@ -3,7 +3,7 @@
 
 #include <gctypes.h>
 
-void btmemr_init();
+void btmemr_init(void);
 void* btmemr_malloc(u32 size);
 void btmemr_free(void *ptr);
 void* btmemr_realloc(void *ptr,u32 newsize);

--- a/lwbt/btpbuf.c
+++ b/lwbt/btpbuf.c
@@ -14,7 +14,7 @@
 MEMB(pool_pbufs,sizeof(struct pbuf)+PBUF_POOL_BUFSIZE,PBUF_POOL_NUM);
 MEMB(rom_pbufs,sizeof(struct pbuf),PBUF_ROM_NUM);
 
-void btpbuf_init()
+void btpbuf_init(void)
 {
 	btmemb_init(&pool_pbufs);
 	btmemb_init(&rom_pbufs);

--- a/lwbt/btpbuf.h
+++ b/lwbt/btpbuf.h
@@ -32,7 +32,7 @@ struct pbuf {
 	u16_t ref;
 };
 
-void btpbuf_init();
+void btpbuf_init(void);
 struct pbuf* btpbuf_alloc(pbuf_layer layer,u16_t len,pbuf_flag flag);
 u8_t btpbuf_free(struct pbuf *p);
 void btpbuf_realloc(struct pbuf *p,u16_t new_len);

--- a/lwbt/hci.c
+++ b/lwbt/hci.c
@@ -356,7 +356,7 @@ err_t hci_read_local_features(void)
 	return ERR_OK;
 }
 
-err_t hci_read_stored_link_key()
+err_t hci_read_stored_link_key(void)
 {
 	struct pbuf *p = NULL;
 	struct hci_link_key *tmpres;
@@ -549,7 +549,7 @@ err_t hci_periodic_inquiry(u32_t lap,u16_t min_period,u16_t max_period,u8_t inq_
 	return ERR_OK;
 }
 
-err_t hci_exit_periodic_inquiry()
+err_t hci_exit_periodic_inquiry(void)
 {
 	struct pbuf *p = NULL;
 
@@ -1178,7 +1178,7 @@ err_t hci_host_num_comp_packets(u16_t conhdl, u16_t num_complete)
  * ACL packet that the Host Controller can buffer.
  */
 /*-----------------------------------------------------------------------------------*/
-u16_t lp_pdu_maxsize()
+u16_t lp_pdu_maxsize(void)
 {
 	return hci_dev->acl_mtu;
 }

--- a/lwbt/hci.h
+++ b/lwbt/hci.h
@@ -365,7 +365,7 @@ void hci_reset_all(void);
 void hci_event_handler(struct pbuf *p);
 void hci_acldata_handler(struct pbuf *p);
 
-err_t hci_reset();
+err_t hci_reset(void);
 err_t hci_read_bd_addr(void);
 err_t hci_set_hc_to_h_fc(void);
 err_t hci_read_buffer_size(void);
@@ -391,14 +391,14 @@ err_t hci_host_num_comp_packets(u16_t conhdl, u16_t num_complete);
 err_t hci_sniff_mode(struct bd_addr *bdaddr, u16_t max_interval, u16_t min_interval, u16_t attempt, u16_t timeout);
 err_t hci_write_link_policy_settings(struct bd_addr *bdaddr, u16_t link_policy);
 err_t hci_periodic_inquiry(u32_t lap,u16_t min_period,u16_t max_period,u8_t inq_len,u8_t num_resp,err_t (*inq_complete)(void *arg,struct hci_pcb *pcb,struct hci_inq_res *ires,u16_t result));
-err_t hci_exit_periodic_inquiry();
+err_t hci_exit_periodic_inquiry(void);
 err_t hci_accecpt_conn_request(struct bd_addr *bdaddr,u8_t role);
 err_t hci_set_event_mask(u64_t ev_mask);
 err_t hci_read_local_version(void);
 err_t hci_read_local_features(void);
 err_t hci_write_local_name(u8_t *name,u8_t len);
 err_t hci_write_pin_type(u8_t type);
-err_t hci_read_stored_link_key();
+err_t hci_read_stored_link_key(void);
 err_t hci_read_remote_name(struct bd_addr *bdaddr);
 err_t hci_vendor_specific_command(u8_t ocf,u8_t ogf,void *data,u8_t len);
 
@@ -413,7 +413,7 @@ void hci_link_key_not(err_t (* link_key_not)(void *arg, struct bd_addr *bdaddr, 
 void hci_wlp_complete(err_t (* wlp_complete)(void *arg, struct bd_addr *bdaddr));
 void hci_conn_req(err_t (*conn_req)(void *arg,struct bd_addr *bdaddr,u8_t *cod,u8_t link_type));
 
-u16_t lp_pdu_maxsize();
+u16_t lp_pdu_maxsize(void);
 u8_t lp_is_connected(struct bd_addr *bdaddr);
 err_t lp_acl_write(struct bd_addr *bdaddr,struct pbuf *p,u16_t len,u8_t pb);
 err_t lp_connect_req(struct bd_addr *bdaddr, u8_t allow_role_switch);

--- a/lwbt/l2cap.c
+++ b/lwbt/l2cap.c
@@ -46,7 +46,7 @@ MEMB(l2cap_segs,sizeof(struct l2cap_seg),MEMB_NUM_L2CAP_SEG);
  * Initializes the L2CAP layer.
  */
 /*-----------------------------------------------------------------------------------*/
-void l2cap_init()
+void l2cap_init(void)
 {
 	btmemb_init(&l2cap_pcbs);
 	btmemb_init(&l2cap_listenpcbs);
@@ -75,7 +75,7 @@ void l2cap_init()
  * time. It also includes a configuration timer.
  */
 /*-----------------------------------------------------------------------------------*/
-void l2cap_tmr()
+void l2cap_tmr(void)
 {
 	struct l2cap_sig *sig;
 	struct l2cap_pcb *pcb;

--- a/lwbt/l2cap.h
+++ b/lwbt/l2cap.h
@@ -217,7 +217,7 @@ struct l2cap_pcb_listen {
 
 #define l2cap_psm(pcb) ((pcb)->psm)
 
-void l2cap_init();
+void l2cap_init(void);
 struct l2cap_pcb* l2cap_new(void);
 
 void lp_connect_ind(struct bd_addr *bdaddr);
@@ -230,7 +230,7 @@ err_t l2ca_datawrite(struct l2cap_pcb *pcb, struct pbuf *p);
 err_t l2ca_ping(struct bd_addr *bdaddr, struct l2cap_pcb *tpcb,err_t (* l2ca_pong)(void *arg, struct l2cap_pcb *pcb, u8_t result));
 err_t l2ca_connect_req(struct l2cap_pcb *pcb, struct bd_addr *bdaddr, u16_t psm, u8_t role_switch, err_t (* l2ca_connect_cfm)(void *arg, struct l2cap_pcb *lpcb,u16_t result, u16_t status));
 
-void l2cap_tmr();
+void l2cap_tmr(void);
 void l2cap_input(struct pbuf *p, struct bd_addr *bdaddr);
 err_t l2cap_close(struct l2cap_pcb *pcb);
 void l2cap_reset_all(void);

--- a/lwbt/physbusif.c
+++ b/lwbt/physbusif.c
@@ -42,10 +42,10 @@ static struct memb_blks aclbufs;
 static u8 __ppc_btstack1[STACKSIZE] ATTRIBUTE_ALIGN(8);
 static u8 __ppc_btstack2[STACKSIZE] ATTRIBUTE_ALIGN(8);
 
-static s32 __issue_bulkread();
-static s32 __issue_intrread();
+static s32 __issue_bulkread(void);
+static s32 __issue_intrread(void);
 
-extern u32 __IPC_ClntInit();
+extern u32 __IPC_ClntInit(void);
 
 static s32 __usb_closeCB(s32 result,void *usrdata)
 {
@@ -125,7 +125,7 @@ static s32 __readintrdataCB(s32 result,void *usrdata)
 	return __issue_intrread();
 }
 
-static s32 __issue_intrread()
+static s32 __issue_intrread(void)
 {
 	s32 ret;
 	u32 len;
@@ -147,7 +147,7 @@ static s32 __issue_intrread()
 	return ret;
 }
 
-static s32 __issue_bulkread()
+static s32 __issue_bulkread(void)
 {
 	s32 ret;
 	u32 len;
@@ -278,7 +278,7 @@ void __ntd_set_pid_vid(u16 vid,u16 pid)
 }
 
 
-void physbusif_init()
+void physbusif_init(void)
 {
 	s32 ret;
 
@@ -288,7 +288,7 @@ void physbusif_init()
 	__usb_open(NULL);
 }
 
-void physbusif_close()
+void physbusif_close(void)
 {
 	if(__usbdev.openstate!=0x0002) return;
 
@@ -296,13 +296,13 @@ void physbusif_close()
 	__wait4hci = 1;
 }
 
-void physbusif_shutdown()
+void physbusif_shutdown(void)
 {
 	if(__usbdev.openstate!=0x0004) return;
 	USB_CloseDeviceAsync(&__usbdev.fd,__usb_closeCB,NULL);
 }
 
-void physbusif_reset_all()
+void physbusif_reset_all(void)
 {
 	return;
 }

--- a/lwbt/physbusif.h
+++ b/lwbt/physbusif.h
@@ -20,10 +20,10 @@ struct _usb_p
 	pbcallback unregcb;		
 };
 
-void physbusif_init();
-void physbusif_close();
-void physbusif_shutdown();
-void physbusif_reset_all();
+void physbusif_init(void);
+void physbusif_close(void);
+void physbusif_shutdown(void);
+void physbusif_reset_all(void);
 void physbusif_output(struct pbuf *p,u16_t len);
 
 #endif


### PR DESCRIPTION
More clean-up and warnings resolved, just in a different lib. After this, #24, and #26 essentially all of the exposed public interface has their prototypes amended except for one function outside of lwbt, which will be fixed in its own PR.