### PR TITLE
gc/network: Add missing void in empty parameter list for net_init()

### DIFF
--- a/gc/network.h
+++ b/gc/network.h
@@ -248,7 +248,7 @@ char *inet_ntoa(struct in_addr addr); /* returns ptr to static buffer; not reent
 s32 if_config( char *local_ip, char *netmask, char *gateway,bool use_dhcp, int max_retries);
 s32 if_configex(struct in_addr *local_ip, struct in_addr *netmask, struct in_addr *gateway, bool use_dhcp, int max_retries);
 
-s32 net_init();
+s32 net_init(void);
 #ifdef HW_RVL
 typedef s32 (*netcallback)(s32 result, void *usrdata);
 s32 net_init_async(netcallback cb, void *usrdata);


### PR DESCRIPTION
The definition already has a void in it, this just amends the prototype to match.