### PR TITLE
libogc/card: Make __card_findnext() internally linked

### DIFF
--- a/libogc/card.c
+++ b/libogc/card.c
@@ -3018,7 +3018,7 @@ s32 CARD_GetErrorCode(s32 chn)
 	return card->result;
 }
 
-s32 __card_findnext(card_dir *dir) 
+static s32 __card_findnext(card_dir *dir) 
 { 
 	s32 ret; 
 	struct card_dat *dirblock = NULL; 


### PR DESCRIPTION
This is only used within this translation unit and nowhere else.