### PR TITLE
libogc/wiisd: Make functions internally linked where applicable

### DIFF
--- a/libogc/wiisd.c
+++ b/libogc/wiisd.c
@@ -500,7 +500,7 @@ static	bool __sd0_initio(void)
 	return false;
 }
 
-bool sdio_Deinitialize(void)
+static bool sdio_Deinitialize(void)
 {
 	if(__sd0_fd>=0)
 		IOS_Close(__sd0_fd);
@@ -510,7 +510,7 @@ bool sdio_Deinitialize(void)
 	return true;
 }
 
-bool sdio_Startup(void)
+static bool sdio_Startup(void)
 {
 	if(__sdio_initialized==1) return true;
  
@@ -537,9 +537,7 @@ bool sdio_Startup(void)
 	return true;
 }
  
- 
- 
-bool sdio_Shutdown(void)
+static bool sdio_Shutdown(void)
 {
 	if(__sd0_initialized==0) return false;
 
@@ -548,8 +546,8 @@ bool sdio_Shutdown(void)
 	__sd0_initialized = 0;
 	return true;
 }
- 
-bool sdio_ReadSectors(sec_t sector, sec_t numSectors,void* buffer)
+
+static bool sdio_ReadSectors(sec_t sector, sec_t numSectors,void* buffer)
 {
 	s32 ret;
 	u8 *ptr;
@@ -586,8 +584,8 @@ bool sdio_ReadSectors(sec_t sector, sec_t numSectors,void* buffer)
  
 	return (ret>=0);
 }
- 
-bool sdio_WriteSectors(sec_t sector, sec_t numSectors,const void* buffer)
+
+static bool sdio_WriteSectors(sec_t sector, sec_t numSectors,const void* buffer)
 {
 	s32 ret;
 	u8 *ptr;
@@ -624,19 +622,19 @@ bool sdio_WriteSectors(sec_t sector, sec_t numSectors,const void* buffer)
  
 	return (ret>=0);
 }
- 
-bool sdio_ClearStatus(void)
+
+static bool sdio_ClearStatus(void)
 {
 	return true;
 }
- 
-bool sdio_IsInserted(void)
+
+static bool sdio_IsInserted(void)
 {
 	return ((__sdio_getstatus() & SDIO_STATUS_CARD_INSERTED) ==
 			SDIO_STATUS_CARD_INSERTED);
 }
 
-bool sdio_IsInitialized(void)
+static bool sdio_IsInitialized(void)
 {
 	return ((__sdio_getstatus() & SDIO_STATUS_CARD_INITIALIZED) ==
 			SDIO_STATUS_CARD_INITIALIZED);

--- a/libogc/wiisd.c
+++ b/libogc/wiisd.c
@@ -643,12 +643,12 @@ static bool sdio_IsInitialized(void)
 const DISC_INTERFACE __io_wiisd = {
 	DEVICE_TYPE_WII_SD,
 	FEATURE_MEDIUM_CANREAD | FEATURE_MEDIUM_CANWRITE | FEATURE_WII_SD,
-	(FN_MEDIUM_STARTUP)&sdio_Startup,
-	(FN_MEDIUM_ISINSERTED)&sdio_IsInserted,
-	(FN_MEDIUM_READSECTORS)&sdio_ReadSectors,
-	(FN_MEDIUM_WRITESECTORS)&sdio_WriteSectors,
-	(FN_MEDIUM_CLEARSTATUS)&sdio_ClearStatus,
-	(FN_MEDIUM_SHUTDOWN)&sdio_Shutdown
+	sdio_Startup,
+	sdio_IsInserted,
+	sdio_ReadSectors,
+	sdio_WriteSectors,
+	sdio_ClearStatus,
+	sdio_Shutdown
 };
 
 #endif


### PR DESCRIPTION
These aren't exposed in any public headers and are only used to form part of the __io_wiisd DISC_INTERFACE instance. Also removes unnecessary function pointer casts that are no longer necessary.