### PR TITLE
libdb: Add missing void in empty function parameter lists

### DIFF
--- a/libdb/debug.c
+++ b/libdb/debug.c
@@ -80,15 +80,15 @@ static struct bp_entry {
 static struct bp_entry *p_bpentries = NULL;
 static frame_context current_thread_registers;
 
-void __breakinst();
+void __breakinst(void);
 void c_debug_handler(frame_context *ctx);
 
-extern void dbg_exceptionhandler();
+extern void dbg_exceptionhandler(frame_context*);
 extern void __exception_sethandler(u32 nExcept, void (*pHndl)(frame_context*));
 
-extern void __clr_iabr();
-extern void __enable_iabr();
-extern void __disable_iabr();
+extern void __clr_iabr(void);
+extern void __enable_iabr(void);
+extern void __disable_iabr(void);
 extern void __set_iabr(void *);
 
 extern const char *tcp_localip;
@@ -97,7 +97,7 @@ extern const char *tcp_gateway;
 extern u8 __text_start[],__data_start[],__bss_start[];
 extern u8 __text_fstart[],__data_fstart[],__bss_fstart[];
 
-static __inline__ void bp_init()
+static __inline__ void bp_init(void)
 {
 	s32 i;
 
@@ -204,7 +204,7 @@ static u32 remove_bp(void *mem)
 	return 1;
 }
 
-static char getdbgchar()
+static char getdbgchar(void)
 {
 	char ch = 0;
 	s32 len = 0;

--- a/libdb/debug_supp.c
+++ b/libdb/debug_supp.c
@@ -252,7 +252,7 @@ lwp_cntrl* gdbstub_indextoid(s32 thread)
 	return NULL;
 }
 
-s32 gdbstub_getcurrentthread()
+s32 gdbstub_getcurrentthread(void)
 {
 	return gdbstub_idtoindex(_thr_executing->object.id);
 }

--- a/libdb/debug_supp.h
+++ b/libdb/debug_supp.h
@@ -11,7 +11,7 @@ struct gdbstub_threadinfo {
 	char name[256];
 };
 
-s32 gdbstub_getcurrentthread();
+s32 gdbstub_getcurrentthread(void);
 s32 hstr2nibble(const char *buf,s32 *nibble);
 char* int2vhstr(char *buf,s32 val);
 char* mem2hstr(char *buf,const char *mem,s32 count);

--- a/libdb/tcpip.c
+++ b/libdb/tcpip.c
@@ -49,7 +49,7 @@ static struct uip_netif netif;
 static struct dbginterface netif_device;
 static struct tcpip_sock *tcpip_accepted_sockets = NULL;
 
-extern s64 gettime();
+extern s64 gettime(void);
 extern u32 diff_msec(s64 start,s64 end);
 
 static s32_t tcpip_allocsocket(struct uip_tcp_pcb *pcb)
@@ -209,7 +209,7 @@ static s8_t tcpip_accept_func(void *arg,struct uip_tcp_pcb *newpcb,s8_t err)
 	return UIP_ERR_OK;
 }
 
-static void __tcpip_poll()
+static void __tcpip_poll(void)
 {
 	u32 diff;
 	s64 now;
@@ -229,7 +229,7 @@ static void __tcpip_poll()
 		tcpip_time = 0;
 }
 
-void tcpip_tmr_needed()
+void tcpip_tmr_needed(void)
 {
 	if(!tcpip_time && (uip_tcp_active_pcbs || uip_tcp_tw_pcbs)) {
 		tcpip_time = gettime();
@@ -286,7 +286,7 @@ struct dbginterface* tcpip_init(struct uip_ip_addr *localip,struct uip_ip_addr *
 	return NULL;
 }
 
-s32_t tcpip_socket()
+s32_t tcpip_socket(void)
 {
 	s32_t s;
 	struct tcpip_sock *sock;

--- a/libdb/tcpip.h
+++ b/libdb/tcpip.h
@@ -43,7 +43,7 @@ struct dbginterface* tcpip_init(struct uip_ip_addr *localip,struct uip_ip_addr *
 void tcpip_close(s32_t s);
 void tcpip_starttimer(s32_t s);
 void tcpip_stoptimer(s32_t s);
-s32_t tcpip_socket();
+s32_t tcpip_socket(void);
 s32_t tcpip_listen(s32_t s,u32_t backlog);
 s32_t tcpip_bind(s32_t s,struct sockaddr *name,socklen_t *namelen);
 s32_t tcpip_accept(s32_t s);

--- a/libdb/uIP/bba.c
+++ b/libdb/uIP/bba.c
@@ -369,7 +369,7 @@ static __inline__ u32 __linkstate()
 	return 0;
 }
 
-static u32 __bba_getlink_state_async()
+static u32 __bba_getlink_state_async(void)
 {
 	u32 ret;
 
@@ -381,7 +381,7 @@ static u32 __bba_getlink_state_async()
 }
 
 
-static u32 __bba_read_cid()
+static u32 __bba_read_cid(void)
 {
 	u16 cmd = 0;
 	u32 cid = 0;
@@ -395,7 +395,7 @@ static u32 __bba_read_cid()
 
 	return cid;
 }
-static void __bba_reset()
+static void __bba_reset(void)
 {
 	bba_out8(0x60,0x00);
 	udelay(10000);
@@ -405,7 +405,7 @@ static void __bba_reset()
 	bba_out8(BBA_NCRA,0x00);
 }
 
-static void __bba_recv_init()
+static void __bba_recv_init(void)
 {
 	bba_out8(BBA_NCRB,(BBA_NCRB_CA|BBA_NCRB_AB));
 	bba_out8(BBA_MISC2,(BBA_MISC2_AUTORCVR));
@@ -551,7 +551,7 @@ static inline void bba_interrupt(u16 *pstatus)
 	*pstatus |= status;
 }
 
-static s8_t bba_dochallengeresponse()
+static s8_t bba_dochallengeresponse(void)
 {
 	u16 status;
 	s32 cnt;

--- a/libdb/uIP/memr.c
+++ b/libdb/uIP/memr.c
@@ -44,7 +44,7 @@ static void plug_holes(struct mem *rmem)
 	}
 }
 
-void memr_init()
+void memr_init(void)
 {
 	struct mem *rmem;
 

--- a/libdb/uIP/memr.h
+++ b/libdb/uIP/memr.h
@@ -3,7 +3,7 @@
 
 #include <gctypes.h>
 
-void memr_init();
+void memr_init(void);
 void* memr_malloc(u32 size);
 void memr_free(void *ptr);
 void* memr_realloc(void *ptr,u32 newsize);

--- a/libdb/uIP/uip_arch.h
+++ b/libdb/uIP/uip_arch.h
@@ -135,7 +135,7 @@ u16_t uip_chksum_pseudo(struct uip_pbuf *p,struct uip_ip_addr *src,struct uip_ip
 
 
 
-extern void tcpip_tmr_needed();
+extern void tcpip_tmr_needed(void);
 #define tcp_tmr_needed		tcpip_tmr_needed
 
 #if UIP_LIBC_MEMFUNCREPLACE

--- a/libdb/uIP/uip_ip.c
+++ b/libdb/uIP/uip_ip.c
@@ -45,7 +45,7 @@ static u8_t uip_reassflags;
 static u8_t uip_reasstmr;
 static s64 uip_reasstime = 0;
 
-extern s64 gettime();
+extern s64 gettime(void);
 
 static struct uip_pbuf* uip_copyfrom_pbuf(struct uip_pbuf *p,u16_t *offset,u8_t *buffer,u16_t len)
 {
@@ -407,7 +407,7 @@ s8_t uip_ipoutput(struct uip_pbuf *p,struct uip_ip_addr *src,struct uip_ip_addr 
 	return uip_ipoutput_if(p,src,dst,ttl,tos,proto,netif);
 }
 
-void uip_ipinit()
+void uip_ipinit(void)
 {
 
 }

--- a/libdb/uIP/uip_ip.h
+++ b/libdb/uIP/uip_ip.h
@@ -121,7 +121,7 @@ struct uip_netif;
 struct ip_addr;
 
 
-void uip_ipinit();
+void uip_ipinit(void);
 
 u32_t uip_ipaddr(const u8_t *cp);
 s32_t uip_ipaton(const u8_t *cp,struct in_addr *addr);

--- a/libdb/uIP/uip_netif.c
+++ b/libdb/uIP/uip_netif.c
@@ -31,7 +31,7 @@ struct uip_stats uip_stat;
 struct uip_netif *uip_netif_list;
 struct uip_netif *uip_netif_default;
 
-void uip_netif_init()
+void uip_netif_init(void)
 {
 	uip_netif_list = uip_netif_default = NULL;
 }

--- a/libdb/uIP/uip_netif.h
+++ b/libdb/uIP/uip_netif.h
@@ -52,7 +52,7 @@ struct uip_netif {
 extern struct uip_netif *uip_netif_list;
 extern struct uip_netif *uip_netif_default;
 
-void uip_netif_init();
+void uip_netif_init(void);
 void uip_netif_setup(struct uip_netif *netif);
 void uip_netif_setaddr(struct uip_netif *netif,struct uip_ip_addr *ipaddr,struct uip_ip_addr *netmask,struct uip_ip_addr *gw);
 void uip_netif_setipaddr(struct uip_netif *netif,struct uip_ip_addr *ipaddr);

--- a/libdb/uIP/uip_pbuf.c
+++ b/libdb/uIP/uip_pbuf.c
@@ -29,7 +29,7 @@ struct uip_stats uip_stat;
 MEMB(uip_pool_pbufs,sizeof(struct uip_pbuf)+UIP_PBUF_POOL_BUFSIZE,UIP_PBUF_POOL_NUM);
 MEMB(uip_rom_pbufs,sizeof(struct uip_pbuf),UIP_PBUF_ROM_NUM);
 
-void uip_pbuf_init()
+void uip_pbuf_init(void)
 {
 	memb_init(&uip_pool_pbufs);
 	memb_init(&uip_rom_pbufs);

--- a/libdb/uIP/uip_pbuf.h
+++ b/libdb/uIP/uip_pbuf.h
@@ -33,7 +33,7 @@ struct uip_pbuf {
 	u16_t ref;
 };
 
-void uip_pbuf_init();
+void uip_pbuf_init(void);
 struct uip_pbuf* uip_pbuf_alloc(uip_pbuf_layer layer,u16_t len,uip_pbuf_flag flag);
 u8_t uip_pbuf_free(struct uip_pbuf *p);
 void uip_pbuf_realloc(struct uip_pbuf *p,u16_t new_len);

--- a/libdb/uIP/uip_tcp.c
+++ b/libdb/uIP/uip_tcp.c
@@ -64,7 +64,7 @@ static s8_t uip_tcpinput_listen(struct uip_tcp_pcb_listen *pcb);
 static s8_t uip_tcpinput_timewait(struct uip_tcp_pcb *pcb);
 static s8_t uip_tcpprocess(struct uip_tcp_pcb *pcb);
 static void uip_tcpreceive(struct uip_tcp_pcb *pcb);
-static u16_t uip_tcp_newport();
+static u16_t uip_tcp_newport(void);
 
 s8_t uip_tcp_sendctrl(struct uip_tcp_pcb *pcb,u8_t flags)
 {
@@ -436,14 +436,14 @@ s8_t uip_tcpoutput(struct uip_tcp_pcb *pcb)
 	return UIP_ERR_OK;
 }
 
-void uip_tcp_tmr()
+void uip_tcp_tmr(void)
 {
 	uip_tcp_fasttmr();
 
 	if(++uip_tcp_timer&1) uip_tcp_slowtmr();
 }
 
-void uip_tcp_init()
+void uip_tcp_init(void)
 {
 	memb_init(&uip_tcp_pcbs);
 	memb_init(&uip_listen_tcp_pcbs);
@@ -789,7 +789,7 @@ void uip_tcp_rexmit_rto(struct uip_tcp_pcb *pcb)
 	uip_tcpoutput(pcb);
 }
 
-void uip_tcp_fasttmr()
+void uip_tcp_fasttmr(void)
 {
 	struct uip_tcp_pcb *pcb;
 
@@ -801,7 +801,7 @@ void uip_tcp_fasttmr()
 	}
 }
 
-void uip_tcp_slowtmr()
+void uip_tcp_slowtmr(void)
 {
 	struct uip_tcp_pcb *prev,*pcb,*pcb2;
 	u32 eff_wnd;
@@ -903,7 +903,7 @@ void uip_tcp_slowtmr()
 	}
 }
 
-u32_t uip_tcpiss_next()
+u32_t uip_tcpiss_next(void)
 {
 	static u32_t iss = 6510;
 	iss += uip_tcp_ticks;

--- a/libdb/uIP/uip_tcp.h
+++ b/libdb/uIP/uip_tcp.h
@@ -219,10 +219,10 @@ extern struct uip_tcp_pcb *uip_tcp_active_pcbs;
 extern struct uip_tcp_pcb *uip_tcp_tw_pcbs;
 extern union uip_tcp_listen_pcbs_t uip_tcp_listen_pcbs;
 
-void uip_tcp_tmr();
-void uip_tcp_slowtmr();
-void uip_tcp_fasttmr();
-void uip_tcp_init();
+void uip_tcp_tmr(void);
+void uip_tcp_slowtmr(void);
+void uip_tcp_fasttmr(void);
+void uip_tcp_init(void);
 void uip_tcp_rst(u32_t seqno,u32_t ackno,struct uip_ip_addr *lipaddr,struct uip_ip_addr *ripaddr,u16_t lport,u16_t rport);
 void uip_tcp_abort(struct uip_tcp_pcb *pcb);
 void uip_tcp_pcbremove(struct uip_tcp_pcb **pcblist,struct uip_tcp_pcb *pcb);
@@ -241,7 +241,7 @@ s8_t uip_tcp_close(struct uip_tcp_pcb *pcb);
 s8_t uip_tcp_bind(struct uip_tcp_pcb *pcb,struct uip_ip_addr *ipaddr,u16_t port);
 s8_t uip_tcp_write(struct uip_tcp_pcb *pcb,const void *arg,u16_t len,u8_t copy);
 struct uip_tcp_pcb* uip_tcp_listen(struct uip_tcp_pcb *pcb);
-struct uip_tcp_pcb* uip_tcp_new();
+struct uip_tcp_pcb* uip_tcp_new(void);
 struct uip_tcp_pcb* uip_tcp_pcballoc(u8_t prio);
 
 s8_t uip_tcp_sendctrl(struct uip_tcp_pcb *pcb,u8_t flags);
@@ -249,7 +249,7 @@ s8_t uip_tcpoutput(struct uip_tcp_pcb *pcb);
 s8_t uip_tcpenqueue(struct uip_tcp_pcb *pcb,void *arg,u16_t len,u8_t flags,u8_t copy,u8_t *optdata,u8_t optlen);
 u8_t uip_tcpseg_free(struct uip_tcpseg *seg);
 u8_t uip_tcpsegs_free(struct uip_tcpseg *seg);
-u32_t uip_tcpiss_next();
+u32_t uip_tcpiss_next(void);
 void uip_tcpinput(struct uip_pbuf *p,struct uip_netif *inp);
 struct uip_tcpseg* uip_tcpseg_copy(struct uip_tcpseg *seg);
 


### PR DESCRIPTION
Silences a bunch more of -Wmissing-prototypes warnings. Note that this also corrects the prototype of dbg_exceptionhandler in debug.c to take a frame_context*, as it's required for the interface that uses it.