### PR TITLE
mp3player: Amend function prototypes

### DIFF
--- a/gc/mp3player.h
+++ b/gc/mp3player.h
@@ -8,9 +8,9 @@
    extern "C" {
 #endif /* __cplusplus */
 
-void MP3Player_Init();
-void MP3Player_Stop();
-BOOL MP3Player_IsPlaying();
+void MP3Player_Init(void);
+void MP3Player_Stop(void);
+BOOL MP3Player_IsPlaying(void);
 void MP3Player_Volume(u32 volume);
 s32 MP3Player_PlayBuffer(const void *buffer,s32 len,void (*filterfunc)(struct mad_stream *,struct mad_frame *));
 s32 MP3Player_PlayFile(void *cb_data,s32 (*reader)(void *,void *,s32),void (*filterfunc)(struct mad_stream *,struct mad_frame *));

--- a/libmad/mp3player.c
+++ b/libmad/mp3player.c
@@ -83,7 +83,7 @@ static lwpq_t thQueue;
 static s32 (*mp3read)(void*,void *,s32);
 static void (*mp3filterfunc)(struct mad_stream *,struct mad_frame *);
 
-static void DataTransferCallback();
+static void DataTransferCallback(s32);
 static void Init3BandState(EQState *es,s32 lowfreq,s32 highfreq,s32 mixfreq);
 static s16 Do3Band(EQState *es,s16 sample);
 static void Resample(struct mad_pcm *Pcm,EQState eqs[2],u32 stereo,u32 src_samplerate);
@@ -215,7 +215,7 @@ static s32 _mp3ramcopy(void *usr_data,void *buffer,s32 len)
 	return len;
 }
 
-void MP3Player_Init()
+void MP3Player_Init(void)
 {
 	if(!init_done) {
 		init_done = 1;
@@ -259,7 +259,7 @@ s32 MP3Player_PlayFile(void *cb_data,s32 (*reader)(void *,void *,s32),void (*fil
 	return 0;
 }
 
-void MP3Player_Stop()
+void MP3Player_Stop(void)
 {
 	if(thr_running==FALSE) return;
 
@@ -267,7 +267,7 @@ void MP3Player_Stop()
 	LWP_JoinThread(hStreamPlay,NULL);
 }
 
-BOOL MP3Player_IsPlaying()
+BOOL MP3Player_IsPlaying(void)
 {
 	return thr_running;
 }
@@ -444,7 +444,7 @@ static s16 Do3Band(EQState *es,s16 sample)
 	return (s16)(l+m+h);
 }
 
-static void DataTransferCallback()
+static void DataTransferCallback(s32 voice)
 {
 #ifndef __SNDLIB_H__
 	AUDIO_InitDMA((u32)OutputBuffer[CurrentBuffer],ADMA_BUFFERSIZE);


### PR DESCRIPTION
This also corrects the function prototype of DataTransferCallback() which should have been specified with an s32 parameter representing a voice, rather than an empty parameter.