### PR TITLE
lwbt/hci: Mark hci_get_link(), hci_cmd_ass(), and bte_hci_initcore_complete2() as internally linked

### DIFF
--- a/lwbt/bte.c
+++ b/lwbt/bte.c
@@ -1074,7 +1074,7 @@ err_t bte_read_bd_addr_complete(void *arg,struct hci_pcb *pcb,u8_t ogf,u8_t ocf,
 }
 
 /* new init with patching */
-err_t bte_hci_initcore_complete2(void *arg,struct hci_pcb *pcb,u8_t ogf,u8_t ocf,u8_t result)
+static err_t bte_hci_initcore_complete2(void *arg,struct hci_pcb *pcb,u8_t ogf,u8_t ocf,u8_t result)
 {
 	err_t err = ERR_OK;
 	u8_t dev_cod[] = {0x04, 0x02,0x40};

--- a/lwbt/hci.c
+++ b/lwbt/hci.c
@@ -97,7 +97,7 @@ struct hci_link* hci_new(void)
 	return link;
 }
 
-struct hci_link* hci_get_link(struct bd_addr *bdaddr)
+static struct hci_link* hci_get_link(struct bd_addr *bdaddr)
 {
 	struct hci_link *link;
 	
@@ -260,7 +260,7 @@ err_t hci_reg_dev_info(struct bd_addr *bdaddr,u8_t *cod,u8_t psrm,u8_t psm,u16_t
 	return ERR_MEM;
 }
 
-struct pbuf* hci_cmd_ass(struct pbuf *p,u8_t ocf,u8_t ogf,u8_t len)
+static struct pbuf* hci_cmd_ass(struct pbuf *p,u8_t ocf,u8_t ogf,u8_t len)
 {
 	((u8_t*)p->payload)[0] = HCI_COMMAND_DATA_PACKET; /* cmd packet type */
 	((u8_t*)p->payload)[1] = (ocf&0xff); /* OCF & OGF */


### PR DESCRIPTION
These aren't used anywhere except within their respective translation units. Silences more -Wmissing-prototypes warnings.