### PR TITLE
libogc/texconv: Add missing include in .c file

### DIFF
--- a/libogc/texconv.c
+++ b/libogc/texconv.c
@@ -28,6 +28,7 @@ distribution.
 
 -------------------------------------------------------------*/
 #include <gctypes.h>
+#include <texconv.h>
 
 void MakeTexture565(const void *src,void *dst,s32 width,s32 height)
 {


### PR DESCRIPTION
Makes MakeTexture565's prototype visible in the .c file, getting rid of a -Wmissing-prototypes warning