### PR TITLE
libogc/usbstorage: Expose USBStorage_Deinitialize() in the public header

### DIFF
--- a/gc/ogc/usbstorage.h
+++ b/gc/ogc/usbstorage.h
@@ -63,6 +63,7 @@ typedef struct {
 } raw_device_command;
 
 s32 USBStorage_Initialize(void);
+void USBStorage_Deinitialize(void);
 
 s32 USBStorage_Open(usbstorage_handle *dev, s32 device_id, u16 vid, u16 pid);
 s32 USBStorage_Close(usbstorage_handle *dev);


### PR DESCRIPTION
This is intended to be callable from user code (otherwise, it obviously can never be disabled). This also resolves a -Wmissing-prototype warning.