### PR TITLE
wiiuse/motion_plus: Include motion_plus.h

### DIFF
--- a/wiiuse/motion_plus.c
+++ b/wiiuse/motion_plus.c
@@ -14,6 +14,7 @@
 #include "wiiboard.h"
 #include "io.h"
 #include "lwp_wkspace.h"
+#include "motion_plus.h"
 
 static void wiiuse_probe_motion_plus_check2(struct wiimote_t *wm, ubyte *data, uword len)
 {


### PR DESCRIPTION
Allows the compiler to see exported functions, eliminating some -Wmissing-prototypes warnings.