### PR TITLE
libogc/system: Expose SYS_ResetPMC() in the public header

### DIFF
--- a/gc/ogc/system.h
+++ b/gc/ogc/system.h
@@ -252,6 +252,7 @@ void SYS_ProtectRange(u32 chan,void *addr,u32 bytes,u32 cntrl);
 void SYS_StartPMC(u32 mcr0val,u32 mcr1val);
 void SYS_DumpPMC(void);
 void SYS_StopPMC(void);
+void SYS_ResetPMC(void);
 
 
 /*! \fn s32 SYS_CreateAlarm(syswd_t *thealarm)


### PR DESCRIPTION
This is likely intended to be exposed to user code. Without it, there would be no way to reset performance counter registers, only start and stop them.

This also silences a -Wmissing-prototypes warning.