### PR TITLE
general: Remove casts in DISC_INTERFACE initializers

### DIFF
--- a/libogc/dvd.c
+++ b/libogc/dvd.c
@@ -2687,10 +2687,10 @@ static bool dvdio_Shutdown(void)
 const DISC_INTERFACE __io_gcdvd = {
 	DEVICE_TYPE_GAMECUBE_DVD,
 	FEATURE_MEDIUM_CANREAD | FEATURE_GAMECUBE_DVD,
-	(FN_MEDIUM_STARTUP)&dvdio_Startup,
-	(FN_MEDIUM_ISINSERTED)&dvdio_IsInserted,
-	(FN_MEDIUM_READSECTORS)&dvdio_ReadSectors,
-	(FN_MEDIUM_WRITESECTORS)&dvdio_WriteSectors,
-	(FN_MEDIUM_CLEARSTATUS)&dvdio_ClearStatus,
-	(FN_MEDIUM_SHUTDOWN)&dvdio_Shutdown
+	dvdio_Startup,
+	dvdio_IsInserted,
+	dvdio_ReadSectors,
+	dvdio_WriteSectors,
+	dvdio_ClearStatus,
+	dvdio_Shutdown
 };

--- a/libogc/gcsd.c
+++ b/libogc/gcsd.c
@@ -155,20 +155,20 @@ static bool __gcsdb_shutdown(void)
 const DISC_INTERFACE __io_gcsda = {
 	DEVICE_TYPE_GC_SD,
 	FEATURE_MEDIUM_CANREAD | FEATURE_MEDIUM_CANWRITE | FEATURE_GAMECUBE_SLOTA,
-	(FN_MEDIUM_STARTUP)&__gcsda_startup,
-	(FN_MEDIUM_ISINSERTED)&__gcsda_isInserted,
-	(FN_MEDIUM_READSECTORS)&__gcsda_readSectors,
-	(FN_MEDIUM_WRITESECTORS)&__gcsda_writeSectors,
-	(FN_MEDIUM_CLEARSTATUS)&__gcsda_clearStatus,
-	(FN_MEDIUM_SHUTDOWN)&__gcsda_shutdown
-} ;
+	__gcsda_startup,
+	__gcsda_isInserted,
+	__gcsda_readSectors,
+	__gcsda_writeSectors,
+	__gcsda_clearStatus,
+	__gcsda_shutdown
+};
 const DISC_INTERFACE __io_gcsdb = {
 	DEVICE_TYPE_GC_SD,
 	FEATURE_MEDIUM_CANREAD | FEATURE_MEDIUM_CANWRITE | FEATURE_GAMECUBE_SLOTB,
-	(FN_MEDIUM_STARTUP)&__gcsdb_startup,
-	(FN_MEDIUM_ISINSERTED)&__gcsdb_isInserted,
-	(FN_MEDIUM_READSECTORS)&__gcsdb_readSectors,
-	(FN_MEDIUM_WRITESECTORS)&__gcsdb_writeSectors,
-	(FN_MEDIUM_CLEARSTATUS)&__gcsdb_clearStatus,
-	(FN_MEDIUM_SHUTDOWN)&__gcsdb_shutdown
-} ;
+	__gcsdb_startup,
+	__gcsdb_isInserted,
+	__gcsdb_readSectors,
+	__gcsdb_writeSectors,
+	__gcsdb_clearStatus,
+	__gcsdb_shutdown
+};

--- a/libogc/gcsd.c
+++ b/libogc/gcsd.c
@@ -56,7 +56,7 @@ static bool __gcsd_startup(int n)
 }
 
 
-static bool __gcsd_readSectors(int n, u32 sector, u32 numSectors, void *buffer)
+static bool __gcsd_readSectors(int n, sec_t sector, sec_t numSectors, void *buffer)
 {
 	s32 ret;
 
@@ -67,7 +67,7 @@ static bool __gcsd_readSectors(int n, u32 sector, u32 numSectors, void *buffer)
 	return false;
 }
 
-static bool __gcsd_writeSectors(int n, u32 sector, u32 numSectors, const void *buffer)
+static bool __gcsd_writeSectors(int n, sec_t sector, sec_t numSectors, const void *buffer)
 {
 	s32 ret;
 
@@ -100,12 +100,12 @@ static bool __gcsda_isInserted(void)
 	return __gcsd_isInserted(0);
 }
 
-static bool __gcsda_readSectors(u32 sector, u32 numSectors, void *buffer)
+static bool __gcsda_readSectors(sec_t sector, sec_t numSectors, void *buffer)
 {
 	return __gcsd_readSectors(0, sector, numSectors, buffer);
 }
 
-static bool __gcsda_writeSectors(u32 sector, u32 numSectors, void *buffer)
+static bool __gcsda_writeSectors(sec_t sector, sec_t numSectors, const void *buffer)
 {
 	return __gcsd_writeSectors(0, sector, numSectors, buffer);
 }
@@ -132,12 +132,12 @@ static bool __gcsdb_isInserted(void)
 	return __gcsd_isInserted(1);
 }
 
-static bool __gcsdb_readSectors(u32 sector, u32 numSectors, void *buffer)
+static bool __gcsdb_readSectors(sec_t sector, sec_t numSectors, void *buffer)
 {
 	return __gcsd_readSectors(1, sector, numSectors, buffer);
 }
 
-static bool __gcsdb_writeSectors(u32 sector, u32 numSectors, void *buffer)
+static bool __gcsdb_writeSectors(sec_t sector, sec_t numSectors, const void *buffer)
 {
 	return __gcsd_writeSectors(1, sector, numSectors, buffer);
 }

--- a/libogc/usbstorage.c
+++ b/libogc/usbstorage.c
@@ -997,12 +997,12 @@ s32 USBStorage_ioctl(int request, ...)
 DISC_INTERFACE __io_usbstorage = {
 	DEVICE_TYPE_WII_USB,
 	FEATURE_MEDIUM_CANREAD | FEATURE_MEDIUM_CANWRITE | FEATURE_WII_USB,
-	(FN_MEDIUM_STARTUP)&__usbstorage_Startup,
-	(FN_MEDIUM_ISINSERTED)&__usbstorage_IsInserted,
-	(FN_MEDIUM_READSECTORS)&__usbstorage_ReadSectors,
-	(FN_MEDIUM_WRITESECTORS)&__usbstorage_WriteSectors,
-	(FN_MEDIUM_CLEARSTATUS)&__usbstorage_ClearStatus,
-	(FN_MEDIUM_SHUTDOWN)&__usbstorage_Shutdown
+	__usbstorage_Startup,
+	__usbstorage_IsInserted,
+	__usbstorage_ReadSectors,
+	__usbstorage_WriteSectors,
+	__usbstorage_ClearStatus,
+	__usbstorage_Shutdown
 };
 
 #endif /* HW_RVL */

--- a/libogc/usbstorage.c
+++ b/libogc/usbstorage.c
@@ -920,7 +920,7 @@ static bool __usbstorage_IsInserted(void)
 	return __mounted;
 }
 
-static bool __usbstorage_ReadSectors(u32 sector, u32 numSectors, void *buffer)
+static bool __usbstorage_ReadSectors(sec_t sector, sec_t numSectors, void *buffer)
 {
 	s32 retval;
 
@@ -932,7 +932,7 @@ static bool __usbstorage_ReadSectors(u32 sector, u32 numSectors, void *buffer)
 	return retval >= 0;
 }
 
-static bool __usbstorage_WriteSectors(u32 sector, u32 numSectors, const void *buffer)
+static bool __usbstorage_WriteSectors(sec_t sector, sec_t numSectors, const void *buffer)
 {
 	s32 retval;
 


### PR DESCRIPTION
This prevents warnings about incompatible function pointer types from being silenced (which actually turned out to be the case in gcsd). This also adjusts the prototypes to use `sec_t` instead of `u32` where applicable, as the `DISC_INTERFACE` struct uses `sec_t` for the parameters. Given that `sec_t` is currently defined as a typedef to `uint32_t` this has no behavioral change.