### PR TITLE
libogc/system: Don't cast away volatile in __dsp_bootstrap()

### DIFF
--- a/libogc/system.c
+++ b/libogc/system.c
@@ -776,9 +776,9 @@ static void __dsp_bootstrap(void)
 	_dspReg[0] = 0;
 	while((_SHIFTL(_dspReg[2],16,16)|(_dspReg[3]&0xffff))&0x80000000);
 
-	((u32*)_dspReg)[8] = 0x01000000;
-	((u32*)_dspReg)[9] = 0;
-	((u32*)_dspReg)[10] = 32;
+	((vu32*)_dspReg)[8] = 0x01000000;
+	((vu32*)_dspReg)[9] = 0;
+	((vu32*)_dspReg)[10] = 32;
 
 	status = _dspReg[5];
 	while(!(status&DSPCR_ARINT)) status = _dspReg[5];
@@ -787,9 +787,9 @@ static void __dsp_bootstrap(void)
 	tick = gettick();
 	while((gettick()-tick)<2194);
 
-	((u32*)_dspReg)[8] = 0x01000000;
-	((u32*)_dspReg)[9] = 0;
-	((u32*)_dspReg)[10] = 32;
+	((vu32*)_dspReg)[8] = 0x01000000;
+	((vu32*)_dspReg)[9] = 0;
+	((vu32*)_dspReg)[10] = 32;
 
 	status = _dspReg[5];
 	while(!(status&DSPCR_ARINT)) status = _dspReg[5];


### PR DESCRIPTION
_dspReg is a volatile-pointer and the C standard lists (in annex J, which lists undefined behavior among other things):

- An attempt is made to refer to an object defined with a volatile-qualified type through
  use of an lvalue with non-volatile-qualified type (6.7.3).

This is very unlikely to break regardless, but it's also trivial to amend (and reduces the amount of -Wcast-qual warnings).