### PR TITLE
libogc/system: Make dsp_initcode const

### DIFF
--- a/libogc/system.c
+++ b/libogc/system.c
@@ -219,7 +219,7 @@ u8 *__argvArena1Lo = (u8*)0xdeadbeef;
 
 static u32 __sys_inIPL = (u32)__isIPL;
 
-static u32 _dsp_initcode[] =
+static const u32 _dsp_initcode[] =
 {
 	0x029F0010,0x029F0033,0x029F0034,0x029F0035,
 	0x029F0036,0x029F0037,0x029F0038,0x029F0039,


### PR DESCRIPTION
This is only ever memcpy'd and not modified, so allow the compiler toss it into the read-only segment