### PR TITLE
gx: fix GX_ReadClksPerVtx() shift

### DIFF
--- a/libogc/gx.c
+++ b/libogc/gx.c
@@ -5066,7 +5066,7 @@ u32 GX_ReadClksPerVtx(void)
 	GX_DrawDone();
 	_cpReg[49] = 0x1007;
 	_cpReg[48] = 0x1007;
-	return (_cpReg[50]<<8);
+	return (_cpReg[50]>>8);
 }
 
 void GX_ClearVCacheMetric(void)


### PR DESCRIPTION
Untested (I only found this bug by looking at disassembly), but @stenzek independently found out the value returned by the left-shifting version of GX_ReadClksPerVtx() had to be shifted right by 16 to be realistic.