### PR TITLE
libogc/dvd: Correct printf specifier in DVD_LowGetStatus()

### DIFF
--- a/libogc/dvd.c
+++ b/libogc/dvd.c
@@ -1928,7 +1928,9 @@ static s32 DVD_LowSetStatus(u32 status,dvdcallbacklow cb)
 static s32 DVD_LowGetStatus(u32 *status,dvdcallbacklow cb)
 {
 #ifdef _DVD_DEBUG
-	printf("DVD_LowSetStatus(%08x)\n",status);
+	if (status) {
+		printf("DVD_LowGetStatus(%08x)\n", *status);
+	}
 #endif
 	__dvd_finalstatuscb = cb;
 	__dvd_usrdata = status;


### PR DESCRIPTION
The previous specifier being used was for an unsigned int, however a pointer variable was being passed instead. Based off the incorrect name of the function in the format string, this was a copy-paste error