### PR TITLE
Add GX_GetViewport(v)

### DIFF
--- a/gc/ogc/gx.h
+++ b/gc/ogc/gx.h
@@ -1837,6 +1837,36 @@ void GX_SetViewport(f32 xOrig,f32 yOrig,f32 wd,f32 ht,f32 nearZ,f32 farZ);
 void GX_SetViewportJitter(f32 xOrig,f32 yOrig,f32 wd,f32 ht,f32 nearZ,f32 farZ,u32 field);
 
 /*!
+ * \fn void GX_GetViewport(f32* xOrig,f32* yOrig,f32* wd,f32* ht,f32* nearZ,f32* farZ)
+ * \brief Gets the current viewport rectangle in screen coordinates.
+ *
+ * \details The screen origin (\a xOrig = 0.0f, \a yOrig = 0.0f) is at the top left corner of the display. The viewport depth parameters are normalized coordinates
+ * from 0.0f - 1.0f.
+ *
+ * \param[in] xOrig left-most X coordinate, in pixels
+ * \param[in] yOrig top-most Y coordinate, in pixels
+ * \param[in] wd width of the viewport, in pixels
+ * \param[in] ht height of the viewport, in pixels
+ * \param[in] nearZ value normalized from 0.0 - 1.0
+ * \param[in] farZ value normalized from 0.0 - 1.0
+ *
+ * \return none
+ */
+void GX_GetViewport(f32* xOrig,f32* yOrig,f32* wd,f32* ht,f32* nearZ,f32* farZ);
+
+/*!
+ * \fn void GX_GetViewportv(f32* vp)
+ * \brief Gets the current viewport rectangle in screen coordinates and places them in an array of minimum size 6.
+ *
+ * \details The order of parameters returned will be the same as the order of GX_SetViewport().
+ *
+ * \param[in] vp A pointer to a floating point array of minimum size 6.
+ *
+ * \return none
+ */
+void GX_GetViewportv(f32* vp);
+
+/*!
  * \fn void GX_SetChanCtrl(s32 channel,u8 enable,u8 ambsrc,u8 matsrc,u8 litmask,u8 diff_fn,u8 attn_fn)
  * \brief Sets the lighting controls for a particular color channel.
  *

--- a/libogc/gx.c
+++ b/libogc/gx.c
@@ -1795,12 +1795,12 @@ void GX_SetViewport(f32 xOrig,f32 yOrig,f32 wd,f32 ht,f32 nearZ,f32 farZ)
 }
 
 void GX_GetViewport(f32* xOrig,f32* yOrig,f32* wd,f32* ht,f32* nearZ,f32* farZ){
-    xOrig = &(_gx_viewport[0]);
-    yOrig = &(_gx_viewport[1]);
-    wd = &(_gx_viewport[2]);
-    ht = &(_gx_viewport[3]);
-    nearZ = &(_gx_viewport[4]);
-    farZ = &(_gx_viewport[5]);
+    *xOrig = _gx_viewport[0];
+    *yOrig = _gx_viewport[1];
+    *wd = _gx_viewport[2];
+    *ht = _gx_viewport[3];
+    *nearZ = _gx_viewport[4];
+    *farZ = _gx_viewport[5];
 }
 
 void GX_GetViewportv(f32* vp){

--- a/libogc/gx.c
+++ b/libogc/gx.c
@@ -130,6 +130,7 @@ static const u32 _gxtexregionaddrtable[48] =
 };
 #endif
 
+static f32 _gx_viewport[6];
 
 extern u8 __gxregs[];
 static struct __gx_regdef *__gx = (struct __gx_regdef*)__gxregs;
@@ -1765,33 +1766,50 @@ void GX_SetMisc(u32 token,u32 value)
 
 void GX_SetViewportJitter(f32 xOrig,f32 yOrig,f32 wd,f32 ht,f32 nearZ,f32 farZ,u32 field)
 {
-	f32 x0,y0,x1,y1,n,f,z;
 	static const f32 Xfactor = 0.5f;
 	static const f32 Yfactor = 342.0f;
 	static const f32 Zfactor = 16777215.0f;
 
 	if(!field) yOrig -= Xfactor;
 
-	x0 = wd*Xfactor;
-	y0 = (-ht)*Xfactor;
-	x1 = (xOrig+(wd*Xfactor))+Yfactor;
-	y1 = (yOrig+(ht*Xfactor))+Yfactor;
-	n = Zfactor*nearZ;
-	f = Zfactor*farZ;
-	z = f-n;
+	_gx_viewport[0] = wd * Xfactor;
+	_gx_viewport[1] = (-ht) * Xfactor;
+	_gx_viewport[2] = (xOrig + (wd * Xfactor)) + Yfactor;
+	_gx_viewport[3] = (yOrig + (ht*Xfactor)) + Yfactor;
+	_gx_viewport[4] = Zfactor * nearZ;
+	_gx_viewport[5] = Zfactor * farZ;
+	_gx_viewport[6] = _gx_viewport[5] - _gx_viewport[4];
 
 	GX_LOAD_XF_REGS(0x101a,6);
-	wgPipe->F32 = x0;
-	wgPipe->F32 = y0;
-	wgPipe->F32 = z;
-	wgPipe->F32 = x1;
-	wgPipe->F32 = y1;
-	wgPipe->F32 = f;
+	wgPipe->F32 = _gx_viewport[0];
+	wgPipe->F32 = _gx_viewport[1];
+	wgPipe->F32 = _gx_viewport[6];
+	wgPipe->F32 = _gx_viewport[2];
+	wgPipe->F32 = _gx_viewport[3];
+	wgPipe->F32 = _gx_viewport[5];
 }
 
 void GX_SetViewport(f32 xOrig,f32 yOrig,f32 wd,f32 ht,f32 nearZ,f32 farZ)
 {
 	GX_SetViewportJitter(xOrig,yOrig,wd,ht,nearZ,farZ,1);
+}
+
+void GX_GetViewport(f32* xOrig,f32* yOrig,f32* wd,f32* ht,f32* nearZ,f32* farZ){
+    xOrig = &(_gx_viewport[0]);
+    yOrig = &(_gx_viewport[1]);
+    wd = &(_gx_viewport[2]);
+    ht = &(_gx_viewport[3]);
+    nearZ = &(_gx_viewport[4]);
+    farZ = &(_gx_viewport[5]);
+}
+
+void GX_GetViewportv(f32* vp){
+    vp[0] = _gx_viewport[0];
+    vp[1] = _gx_viewport[1];
+    vp[2] = _gx_viewport[2];
+    vp[3] = _gx_viewport[3])
+    vp[4] = _gx_viewport[4];
+    vp[5] = _gx_viewport[5];
 }
 
 void GX_LoadProjectionMtx(Mtx44 mt,u8 type)


### PR DESCRIPTION
Stores Viewport information in a static array after the math is done. Reasoning for adding it is that games used similar for keeping track of viewport state without having to track it locally.

May be better in a struct to help convey variables and the "v" version may not be totally correct versus the original implementation, so I'm open to changing it. Just wanted to get it on the table.