### PR TITLE
Fix POLL* definitions per Dolphin

### DIFF
--- a/gc/network.h
+++ b/gc/network.h
@@ -195,12 +195,16 @@ struct linger {
 #define ip4_addr4(ipaddr) ((u32)(ntohl((ipaddr)->s_addr)) & 0xff)
 #endif
 
-#define POLLIN				0x0001
-#define POLLPRI				0x0002
-#define POLLOUT				0x0004
-#define POLLERR				0x0008
-#define POLLHUP				0x0010
-#define POLLNVAL			0x0020
+#define POLLRDNORM			0x0001
+#define POLLRDBAND			0x0002
+#define POLLPRI				0x0004
+#define POLLWRNORM			0x0008
+#define POLLWRBAND			0x0010
+#define POLLERR				0x0020
+#define POLLHUP				0x0040
+#define POLLNVAL			0x0080
+#define POLLIN				(POLLRDNORM|POLLRDBAND)
+#define POLLOUT				POLLWRNORM
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
Cf. https://github.com/dolphin-emu/dolphin/blob/master/Source/Core/Core/IOS/Network/IP/Top.cpp#L608-L609
These `#define`s don't affect lwip/GC networking at all. The `POLLIN` mask is defined per POSIX:
> [The POLLIN] flag shall be equivalent to POLLRDNORM | POLLRDBAND.