### PR TITLE
lwIP fixes

### DIFF
--- a/gc/lwip/lwipopts.h
+++ b/gc/lwip/lwipopts.h
@@ -34,9 +34,6 @@
 
 #include <string.h>
 
-#undef BYTE_ORDER
-
-#define BYTE_ORDER						BIG_ENDIAN
 #define NO_SYS							1
 #define LWIP_CALLBACK_API				1
 #undef  LWIP_EVENT_API
@@ -118,7 +115,7 @@ a lot of data that needs to be copied, this should be set high. */
 #define TCP_SND_QUEUELEN        (36*TCP_SND_BUF/TCP_MSS)
 
 /* TCP receive window. */
-#define TCP_WND                 (36*TCP_MSS)
+#define TCP_WND                 (TCP_MSS)
 
 /* Maximum number of retransmissions of data segments. */
 #define TCP_MAXRTX              12

--- a/lwip/arch/gc/netif/gcif.c
+++ b/lwip/arch/gc/netif/gcif.c
@@ -573,7 +573,7 @@ static u32 __bba_tx_err(u8 status,struct bba_priv *priv)
 
 static u32 __bba_rx_err(u8 status,struct bba_priv *priv)
 {
-	u32 last_errors = priv->txrx_stats.tx_errors;
+	u32 last_errors = priv->txrx_stats.rx_errors;
 
 	if(status&0xff) {
 		priv->txrx_stats.rx_overerrors++;
@@ -664,8 +664,6 @@ static err_t __bba_link_tx(struct netif *dev,struct pbuf *p)
 	}
 
 	LWIP_DEBUGF(NETIF_DEBUG,("__bba_link_tx(%d,%p)\n",p->tot_len,LWP_GetSelf()));
-
-	bba_out12(BBA_TXFIFOCNT,p->tot_len);
 
 	bba_select();
 	bba_outsregister(BBA_WRTXFIFOD);

--- a/lwip/core/ipv4/ip.c
+++ b/lwip/core/ipv4/ip.c
@@ -378,7 +378,7 @@ ip_output_if(struct pbuf *p, struct ip_addr *src, struct ip_addr *dest,
              u8_t proto, struct netif *netif)
 {
   struct ip_hdr *iphdr;
-  u16_t ip_id = 0;
+  static u16_t ip_id = 0;
 
   snmp_inc_ipoutrequests();
 


### PR DESCRIPTION
This is necessary to make TCP usable with 100BASE-TX due to the BBA's 2 KiB receive buffer constantly suffering from buffer overruns due to the 27 Mbps EXI bottleneck.