### PR TITLE
Support Game Boy Player Start-Up Disc settings

### DIFF
--- a/gc/ogc/system.h
+++ b/gc/ogc/system.h
@@ -174,7 +174,8 @@ struct _syssram {
  * \param dvderr_code last non-recoverable error from DVD interface
  * \param __padding0 padding
  * \param flashID_chksum[2] 8bit checksum of unlock flash ID
- * \param __padding1[4] padding
+ * \param gbs Game Boy Player Start-Up Disc settings
+ * \param __padding1 padding
  */
 typedef struct _syssramex syssramex;
 
@@ -185,7 +186,8 @@ struct _syssramex {
 	u8 dvderr_code;
 	u8 __padding0;
 	u8 flashID_chksum[2];
-	u8 __padding1[4];
+	u16 gbs;
+	u16 __padding1;
 } ATTRIBUTE_PACKED;
 
 typedef void (*alarmcallback)(syswd_t alarm,void *cb_arg);
@@ -306,6 +308,8 @@ s32 SYS_CancelAlarm(syswd_t thealarm);
 
 void SYS_SetWirelessID(u32 chan,u32 id);
 u32 SYS_GetWirelessID(u32 chan);
+void SYS_SetGBSMode(u16 mode);
+u16 SYS_GetGBSMode(void);
 u32 SYS_GetFontEncoding(void);
 u32 SYS_InitFont(sys_fontheader *font_data);
 void SYS_GetFontTexture(s32 c,void **image,s32 *xpos,s32 *ypos,s32 *width);

--- a/libogc/system.c
+++ b/libogc/system.c
@@ -667,6 +667,8 @@ void __sram_init(void)
 	sramcntrl.sync = __sram_read(sramcntrl.srambuf);
 
 	sramcntrl.offset = 64;
+
+	SYS_SetGBSMode(SYS_GetGBSMode());
 }
 
 static void DisableWriteGatherPipe(void)
@@ -1662,6 +1664,32 @@ u32 SYS_GetWirelessID(u32 chan)
 	id = sram->wirelessPad_id[chan];
 	__SYS_UnlockSramEx(0);
 	return id;
+}
+
+void SYS_SetGBSMode(u16 mode)
+{
+	u32 write;
+	syssramex *sramex;
+
+	write = 0;
+	sramex = __SYS_LockSramEx();
+	if(_SHIFTR(mode,10,5)>=20 || _SHIFTR(mode,6,2)==0x3 || (mode&0x3f)>=60) mode = 0;
+	if(sramex->gbs!=mode) {
+		sramex->gbs = mode;
+		write = 1;
+	}
+	__SYS_UnlockSramEx(write);
+}
+
+u16 SYS_GetGBSMode(void)
+{
+	u16 mode;
+	syssramex *sramex;
+
+	sramex = __SYS_LockSramEx();
+	mode = sramex->gbs;
+	__SYS_UnlockSramEx(0);
+	return mode;
 }
 
 #if defined(HW_RVL)


### PR DESCRIPTION
The intent behind this is to prevent reuse of padding for other applications, and clear invalid settings as done by later versions of the Dolphin SDK and all versions of the Revolution SDK.

The check has been somewhat enhanced from the Dolphin/Revolution SDK, but does not still include checking of the parity bit. That's down to the Game Boy Player Start-Up Disc and Game Boy Interface.