### PR TITLE
SD card improvements

### DIFF
--- a/gc/sdcard/card_io.h
+++ b/gc/sdcard/card_io.h
@@ -49,10 +49,11 @@ s32 sdgecko_doUnmount(s32 drv_no);
 void sdgecko_insertedCB(s32 drv_no);
 void sdgecko_ejectedCB(s32 drv_no);
 
-void sdgecko_setSpeed(u32 freq);
+u32 sdgecko_getSpeed(s32 drv_no);
+void sdgecko_setSpeed(s32 drv_no, u32 freq);
 
 u32 sdgecko_getPageSize(s32 drv_no);
-u32 sdgecko_setPageSize(s32 drv_no, int size);
+s32 sdgecko_setPageSize(s32 drv_no, u32 size);
 
 card_addressing_type_t sdgecko_getAddressingType(s32 drv_no);
 

--- a/libogc/exi.c
+++ b/libogc/exi.c
@@ -171,6 +171,7 @@ static s32 __exi_probe(s32 nChn)
 #ifdef _EXI_DEBUG
 	printf("__exi_probe(%d)\n",nChn);
 #endif
+	if(nChn==EXI_CHANNEL_2) return ret;
 	_CPU_ISR_Disable(level);
 	val = _exiReg[nChn*5];
 	if(!(exi->flags&EXI_FLAG_ATTACH)) {

--- a/libogc/exi.c
+++ b/libogc/exi.c
@@ -892,7 +892,7 @@ void __SYS_EnableBarnacle(s32 chn,u32 dev)
 	if(EXI_GetID(chn,dev,&id)==0) return;
 
 	if(id==0x01020000 || id==0x0004 || id==0x80000010 || id==0x80000008
-		|| id==0x80000004 || id==0xffff || id==0x80000020 || id==0x0020
+		|| id==0x80000004 || id==0xffffffff || id==0x80000020 || id==0x0020
 		|| id==0x0010 || id==0x0008 || id==0x01010000 || id==0x04040404
 		|| id==0x04021000 || id==0x03010000 || id==0x02020000
 		|| id==0x04020300 || id==0x04020200 || id==0x04130000

--- a/libogc/sdgecko_io.c
+++ b/libogc/sdgecko_io.c
@@ -1221,8 +1221,6 @@ s32 sdgecko_initIO(s32 drv_no)
 		if((_ioResponse[drv_no][3]==1) && (_ioResponse[drv_no][4]==0xAA)) _initType[drv_no] = TYPE_SDHC;
 
 		if(__card_sendopcond(drv_no)!=0) goto exit;
-		if(__card_readcsd(drv_no)!=0) goto exit;
-		if(__card_readcid(drv_no)!=0) goto exit;
 
 		if(_initType[drv_no]==TYPE_SDHC) {
 			if(__card_sendCMD58(drv_no)!=0) goto exit;
@@ -1234,7 +1232,7 @@ s32 sdgecko_initIO(s32 drv_no)
 			}
 		}
 
-		_ioPageSize[drv_no] = 1<<WRITE_BL_LEN(drv_no);
+		_ioPageSize[drv_no] = PAGE_SIZE512;
 		if(__card_setblocklen(drv_no,_ioPageSize[drv_no])!=0) goto exit; 
 
 		if(__card_sd_status(drv_no)!=0) goto exit;

--- a/libogc/sdgecko_io.c
+++ b/libogc/sdgecko_io.c
@@ -1138,7 +1138,7 @@ static bool __card_check(s32 drv_no)
 	while((ret=EXI_ProbeEx(drv_no))==0);
 	if(ret!=1) return FALSE;
 	EXI_GetID(drv_no,EXI_DEVICE_0,&id);
-	if(id!=-1) return FALSE;
+	if(!id || id!=(0xffffffffu>>cntlzw(id))) return FALSE;
 
 	if(drv_no!=2) {
 		if(!(EXI_GetState(drv_no)&EXI_FLAG_ATTACH)) {


### PR DESCRIPTION
A few notes:
1. The EXI changes match the Dolphin SDK.
2. Nobody knows what _ioWPFlag was needed for. It doesn't appear to be needed by anything in circulation and only caused trouble when enumerating SD cards.
3. Kingston SD cards made about 10 years ago failed the CSD/CID read.