### PR TITLE
Add missing SRAM getters/setters

### DIFF
--- a/gc/ogc/system.h
+++ b/gc/ogc/system.h
@@ -98,9 +98,22 @@ distribution.
  *@}
  */
 
+#define SYS_LANG_ENGLISH				0
+#define SYS_LANG_GERMAN					1
+#define SYS_LANG_FRENCH					2
+#define SYS_LANG_SPANISH				3
+#define SYS_LANG_ITALIAN				4
+#define SYS_LANG_DUTCH					5
+
+#define SYS_SOUND_MONO					0
+#define SYS_SOUND_STEREO				1
+
+#define SYS_VIDEO_NTSC					0
+#define SYS_VIDEO_PAL					1
+#define SYS_VIDEO_MPAL					2
+
 #define SYS_FONTSIZE_ANSI				(288 + 131072)
 #define SYS_FONTSIZE_SJIS				(3840 + 1179648)
-
 
 
 /*!
@@ -306,10 +319,25 @@ s32 SYS_RemoveAlarm(syswd_t thealarm);
 s32 SYS_CancelAlarm(syswd_t thealarm);
 
 
-void SYS_SetWirelessID(u32 chan,u32 id);
-u32 SYS_GetWirelessID(u32 chan);
-void SYS_SetGBSMode(u16 mode);
+u32 SYS_GetCounterBias(void);
+void SYS_SetCounterBias(u32 bias);
+s8 SYS_GetDisplayOffsetH(void);
+void SYS_SetDisplayOffsetH(s8 offset);
+u8 SYS_GetEuRGB60(void);
+void SYS_SetEuRGB60(u8 enable);
+u8 SYS_GetLanguage(void);
+void SYS_SetLanguage(u8 lang);
+u8 SYS_GetProgressiveScan(void);
+void SYS_SetProgressiveScan(u8 enable);
+u8 SYS_GetSoundMode(void);
+void SYS_SetSoundMode(u8 mode);
+u8 SYS_GetVideoMode(void);
+void SYS_SetVideoMode(u8 mode);
+u16 SYS_GetWirelessID(u32 chan);
+void SYS_SetWirelessID(u32 chan,u16 id);
 u16 SYS_GetGBSMode(void);
+void SYS_SetGBSMode(u16 mode);
+
 u32 SYS_GetFontEncoding(void);
 u32 SYS_InitFont(sys_fontheader *font_data);
 void SYS_GetFontTexture(s32 c,void **image,s32 *xpos,s32 *ypos,s32 *width);

--- a/libogc/system.c
+++ b/libogc/system.c
@@ -1640,30 +1640,215 @@ void SYS_DumpPMC(void)
 	printf("<%u load/stores / %u miss cycles / %u cycles / %u instructions>\n",mfpmc1(),mfpmc2(),mfpmc3(),mfpmc4());
 }
 
-void SYS_SetWirelessID(u32 chan,u32 id)
+u32 SYS_GetCounterBias(void)
+{
+	u32 bias;
+	syssram *sram;
+
+	sram = __SYS_LockSram();
+	bias = sram->counter_bias;
+	__SYS_UnlockSram(0);
+	return bias;
+}
+
+void SYS_SetCounterBias(u32 bias)
 {
 	u32 write;
-	syssramex *sram;
+	syssram *sram;
 
 	write = 0;
-	sram = __SYS_LockSramEx();
-	if(sram->wirelessPad_id[chan]!=(u16)id) {
-		sram->wirelessPad_id[chan] = (u16)id;
+	sram = __SYS_LockSram();
+	if(sram->counter_bias!=bias) {
+		sram->counter_bias = bias;
+		write = 1;
+	}
+	__SYS_UnlockSram(write);
+}
+
+s8 SYS_GetDisplayOffsetH(void)
+{
+	s8 offset;
+	syssram *sram;
+
+	sram = __SYS_LockSram();
+	offset = sram->display_offsetH;
+	__SYS_UnlockSram(0);
+	return offset;
+}
+
+void SYS_SetDisplayOffsetH(s8 offset)
+{
+	u32 write;
+	syssram *sram;
+
+	write = 0;
+	sram = __SYS_LockSram();
+	if(sram->display_offsetH!=offset) {
+		sram->display_offsetH = offset;
+		write = 1;
+	}
+	__SYS_UnlockSram(write);
+}
+
+u8 SYS_GetEuRGB60(void)
+{
+	u8 enable;
+	syssram *sram;
+
+	sram = __SYS_LockSram();
+	enable = _SHIFTR(sram->ntd,6,1);
+	__SYS_UnlockSram(0);
+	return enable;
+}
+
+void SYS_SetEuRGB60(u8 enable)
+{
+	u32 write;
+	syssram *sram;
+
+	write = 0;
+	sram = __SYS_LockSram();
+	if(_SHIFTR(sram->ntd,6,1)!=enable) {
+		sram->ntd = (sram->ntd&~0x40)|(_SHIFTL(enable,6,1));
+		write = 1;
+	}
+	__SYS_UnlockSram(write);
+}
+
+u8 SYS_GetLanguage(void)
+{
+	u8 lang;
+	syssram *sram;
+
+	sram = __SYS_LockSram();
+	lang = sram->lang;
+	__SYS_UnlockSram(0);
+	return lang;
+}
+
+void SYS_SetLanguage(u8 lang)
+{
+	u32 write;
+	syssram *sram;
+
+	write = 0;
+	sram = __SYS_LockSram();
+	if(sram->lang!=lang) {
+		sram->lang = lang;
+		write = 1;
+	}
+	__SYS_UnlockSram(write);
+}
+
+u8 SYS_GetProgressiveScan(void)
+{
+	u8 enable;
+	syssram *sram;
+
+	sram = __SYS_LockSram();
+	enable = _SHIFTR(sram->flags,7,1);
+	__SYS_UnlockSram(0);
+	return enable;
+}
+
+void SYS_SetProgressiveScan(u8 enable)
+{
+	u32 write;
+	syssram *sram;
+
+	write = 0;
+	sram = __SYS_LockSram();
+	if(_SHIFTR(sram->flags,7,1)!=enable) {
+		sram->flags = (sram->flags&~0x80)|(_SHIFTL(enable,7,1));
+		write = 1;
+	}
+	__SYS_UnlockSram(write);
+}
+
+u8 SYS_GetSoundMode(void)
+{
+	u8 mode;
+	syssram *sram;
+
+	sram = __SYS_LockSram();
+	mode = _SHIFTR(sram->flags,2,1);
+	__SYS_UnlockSram(0);
+	return mode;
+}
+
+void SYS_SetSoundMode(u8 mode)
+{
+	u32 write;
+	syssram *sram;
+
+	write = 0;
+	sram = __SYS_LockSram();
+	if(_SHIFTR(sram->flags,2,1)!=mode) {
+		sram->flags = (sram->flags&~0x04)|(_SHIFTL(mode,2,1));
+		write = 1;
+	}
+	__SYS_UnlockSram(write);
+}
+
+u8 SYS_GetVideoMode(void)
+{
+	u8 mode;
+	syssram *sram;
+
+	sram = __SYS_LockSram();
+	mode = (sram->flags&0x03);
+	__SYS_UnlockSram(0);
+	return mode;
+}
+
+void SYS_SetVideoMode(u8 mode)
+{
+	u32 write;
+	syssram *sram;
+
+	write = 0;
+	sram = __SYS_LockSram();
+	if((sram->flags&0x03)!=mode) {
+		sram->flags = (sram->flags&~0x03)|(mode&0x03);
+		write = 1;
+	}
+	__SYS_UnlockSram(write);
+}
+
+u16 SYS_GetWirelessID(u32 chan)
+{
+	u16 id;
+	syssramex *sramex;
+
+	sramex = __SYS_LockSramEx();
+	id = sramex->wirelessPad_id[chan];
+	__SYS_UnlockSramEx(0);
+	return id;
+}
+
+void SYS_SetWirelessID(u32 chan,u16 id)
+{
+	u32 write;
+	syssramex *sramex;
+
+	write = 0;
+	sramex = __SYS_LockSramEx();
+	if(sramex->wirelessPad_id[chan]!=id) {
+		sramex->wirelessPad_id[chan] = id;
 		write = 1;
 	}
 	__SYS_UnlockSramEx(write);
 }
 
-u32 SYS_GetWirelessID(u32 chan)
+u16 SYS_GetGBSMode(void)
 {
-	u16 id;
-	syssramex *sram;
+	u16 mode;
+	syssramex *sramex;
 
-	id = 0;
-	sram = __SYS_LockSramEx();
-	id = sram->wirelessPad_id[chan];
+	sramex = __SYS_LockSramEx();
+	mode = sramex->gbs;
 	__SYS_UnlockSramEx(0);
-	return id;
+	return mode;
 }
 
 void SYS_SetGBSMode(u16 mode)
@@ -1679,17 +1864,6 @@ void SYS_SetGBSMode(u16 mode)
 		write = 1;
 	}
 	__SYS_UnlockSramEx(write);
-}
-
-u16 SYS_GetGBSMode(void)
-{
-	u16 mode;
-	syssramex *sramex;
-
-	sramex = __SYS_LockSramEx();
-	mode = sramex->gbs;
-	__SYS_UnlockSramEx(0);
-	return mode;
 }
 
 #if defined(HW_RVL)

--- a/libogc/video.c
+++ b/libogc/video.c
@@ -1792,19 +1792,15 @@ static inline void __adjustPosition(u16 acv)
 
 static inline void __importAdjustingValues(void)
 {
-#ifdef HW_DOL
-	syssram *sram;
-
-	sram = __SYS_LockSram();
-	displayOffsetH = sram->display_offsetH;
-	__SYS_UnlockSram(0);
-#else
+#if defined(HW_RVL)
 	s8 offset;
 	if ( CONF_GetDisplayOffsetH(&offset) == 0 ) {
 		displayOffsetH = offset;
 	} else {
 		displayOffsetH = 0;
 	}
+#else
+	displayOffsetH = SYS_GetDisplayOffsetH();
 #endif
 	displayOffsetV = 0;
 }
@@ -2592,36 +2588,38 @@ GXRModeObj *rmode = NULL;
 		}
 	}
 #else
-	u32 tvmode = VIDEO_GetCurrentTvMode();
-	if (VIDEO_HaveComponentCable()) {
+	u32 tvmode = SYS_GetVideoMode();
+	if (SYS_GetProgressiveScan() && VIDEO_HaveComponentCable()) {
 		switch (tvmode) {
-			case VI_NTSC:
+			case SYS_VIDEO_NTSC:
 				rmode = &TVNtsc480Prog;
 				break;
-			case VI_PAL:
-				rmode = &TVPal576ProgScale;
+			case SYS_VIDEO_PAL:
+				if (SYS_GetEuRGB60())
+					rmode = &TVEurgb60Hz480Prog;
+				else rmode = &TVPal576ProgScale;
 				break;
-			case VI_MPAL:
+			case SYS_VIDEO_MPAL:
 				rmode = &TVMpal480Prog;
 				break;
-			case VI_EURGB60:
-				rmode = &TVEurgb60Hz480Prog;
-				break;
+			default:
+				rmode = &TVNtsc480Prog;
 		}
 	} else {
 		switch (tvmode) {
-			case VI_NTSC:
+			case SYS_VIDEO_NTSC:
 				rmode = &TVNtsc480IntDf;
 				break;
-			case VI_PAL:
-				rmode = &TVPal576IntDfScale;
+			case SYS_VIDEO_PAL:
+				if (SYS_GetEuRGB60())
+					rmode = &TVEurgb60Hz480IntDf;
+				else rmode = &TVPal576IntDfScale;
 				break;
-			case VI_MPAL:
+			case SYS_VIDEO_MPAL:
 				rmode = &TVMpal480IntDf;
 				break;
-			case VI_EURGB60:
-				rmode = &TVEurgb60Hz480IntDf;
-				break;
+			default:
+				rmode = &TVNtsc480IntDf;
 		}
 	}
 #endif


### PR DESCRIPTION
An alternative to #79 that's consistent in code style.

This also make the preferred video mode be based upon these settings.
Note that the retail IPL does not set the video mode in SRAM, but Swiss and the Wii System Menu does.