### PR TITLE
introduce LWP_SemGetValue

### DIFF
--- a/gc/ogc/semaphore.h
+++ b/gc/ogc/semaphore.h
@@ -80,6 +80,14 @@ s32 LWP_SemDestroy(sem_t sem);
 */
 s32 LWP_SemWait(sem_t sem);
 
+/*! \fn s32 LWP_SemGetValue(sem_t sem, u32* value)
+\brief return the current semaphore count
+\param[in] sem handle to the sem_t structure.
+\param[out] the current value of the semaphore
+
+\return 0 on success, <0 on error
+*/
+s32 LWP_SemGetValue(sem_t sem, u32* value);
 
 /*! \fn s32 LWP_SemPost(sem_t sem)
 \brief Count up semaphore counter and release lock if counter >0

--- a/libogc/semaphore.c
+++ b/libogc/semaphore.c
@@ -128,6 +128,21 @@ s32 LWP_SemWait(sem_t sem)
 	return 0;
 }
 
+s32 LWP_SemGetValue(sem_t sem, u32* value)
+{
+	if(value == NULL)
+		return -1;
+	
+	sema_st *lwp_sem;
+
+	lwp_sem = __lwp_sema_open(sem);
+	if(!lwp_sem) return -1;
+	
+	*value = lwp_sem->sema.count;
+
+	return 0;
+}
+
 s32 LWP_SemPost(sem_t sem)
 {
 	sema_st *lwp_sem;


### PR DESCRIPTION
while discovering semaphore's i noticed the code apparently doesn't have the [GetValue](https://www.man7.org/linux/man-pages/man3/sem_getvalue.3.html) function , which returns the semaphore value. 

it can be used to check on the state of the semaphore (in my testing i used it to see if a SemPost was left unhandled when shutting down, which could signal its still busy)