### PR TITLE
don't inline pbuf_pool_alloc to avoid bad optimization

### DIFF
--- a/lwip/core/pbuf.c
+++ b/lwip/core/pbuf.c
@@ -133,6 +133,7 @@ pbuf_init(void)
  * @internal only called from pbuf_alloc()
  */
 static struct pbuf *
+__attribute__ ((noinline))
 pbuf_pool_alloc(void)
 {
   struct pbuf *p = NULL;


### PR DESCRIPTION
I was struggling to get DHCP working on GameCube, and found that the GameCube was sending DHCP discovery messages, and the router was responding with offers, but GC wasn't handling them. Some debugging found that `pbuf_pool_alloc` was unexpectedly returning `NULL` so the incoming packets were received but not processed.

While debugging this I found that sticking a `puts` right here in `pbuf_pool_alloc`:

```
    p = pbuf_pool;
    if (p) {
      puts("WTF"); // added by me
      pbuf_pool = p->next;
    }
```

... resolved the problem. Checking the disassembly it's not clear to me what the problem is, but adding this `puts` avoids inlining `pbuf_pool_alloc` into `pbuf_alloc` and DHCP now works for me.

This is also resolved by building without `-O2`, or, simply using the `noinline` attribute as I've done here. That seems like the least obtrusive fix.