### PR TITLE
ogc: Cleanup and add memory clobbers to ISR operations

### DIFF
--- a/gc/ogc/machine/processor.h
+++ b/gc/ogc/machine/processor.h
@@ -102,57 +102,65 @@
 { __asm__ __volatile__  ("mtmsr %0" : "=&r" ((_msr_value)) : "0" ((_msr_value))); }
 
 #define _CPU_ISR_Enable() \
-	{ register u32 _val = 0; \
-	  __asm__ __volatile__ ( \
-		"mfmsr %0\n" \
-		"ori %0,%0,0x8000\n" \
-		"mtmsr %0" \
-		: "=&r" ((_val)) : "0" ((_val)) \
-	  ); \
+	{ \
+		register u32 _val = 0; \
+		__asm__ __volatile__ ( \
+			"mfmsr %0\n" \
+			"ori %0,%0,0x8000\n" \
+			"mtmsr %0" \
+			: "=&r" ((_val)) : "0" ((_val)) \
+			: : "memory" \
+		); \
 	}
 
 #define _CPU_ISR_Disable( _isr_cookie ) \
-  { register u32 _disable_mask = 0; \
-	_isr_cookie = 0; \
-    __asm__ __volatile__ ( \
-	  "mfmsr %0\n" \
-	  "rlwinm %1,%0,0,17,15\n" \
-	  "mtmsr %1\n" \
-	  "extrwi %0,%0,1,16" \
-	  : "=&r" ((_isr_cookie)), "=&r" ((_disable_mask)) \
-	  : "0" ((_isr_cookie)), "1" ((_disable_mask)) \
-	); \
-  }
+	{ \
+		register u32 _disable_mask = 0; \
+		_isr_cookie = 0; \
+		__asm__ __volatile__ ( \
+			"mfmsr %0\n" \
+			"rlwinm %1,%0,0,17,15\n" \
+			"mtmsr %1\n" \
+			"extrwi %0,%0,1,16" \
+			: "=&r" ((_isr_cookie)), "=&r" ((_disable_mask)) \
+			: "0" ((_isr_cookie)), "1" ((_disable_mask)) \
+			: "memory" \
+		); \
+	}
 
 #define _CPU_ISR_Restore( _isr_cookie )  \
-  { register u32 _enable_mask = 0; \
-	__asm__ __volatile__ ( \
-    "    cmpwi %0,0\n" \
-	"    beq 1f\n" \
-	"    mfmsr %1\n" \
-	"    ori %1,%1,0x8000\n" \
-	"    mtmsr %1\n" \
-	"1:" \
-	: "=r"((_isr_cookie)),"=&r" ((_enable_mask)) \
-	: "0"((_isr_cookie)),"1" ((_enable_mask)) \
-	); \
-  }
+	{ \
+		register u32 _enable_mask = 0; \
+		__asm__ __volatile__ ( \
+			"cmpwi %0,0\n" \
+			"beq 1f\n" \
+			"mfmsr %1\n" \
+			"ori %1,%1,0x8000\n" \
+			"mtmsr %1\n" \
+			"1:" \
+			: "=r"((_isr_cookie)),"=&r" ((_enable_mask)) \
+			: "0"((_isr_cookie)),"1" ((_enable_mask)) \
+			: "memory" \
+		); \
+	}
 
 #define _CPU_ISR_Flash( _isr_cookie ) \
-  { register u32 _flash_mask = 0; \
-    __asm__ __volatile__ ( \
-    "   cmpwi %0,0\n" \
-	"   beq 1f\n" \
-	"   mfmsr %1\n" \
-	"   ori %1,%1,0x8000\n" \
-	"   mtmsr %1\n" \
-	"   rlwinm %1,%1,0,17,15\n" \
-	"   mtmsr %1\n" \
-	"1:" \
-    : "=r" ((_isr_cookie)), "=&r" ((_flash_mask)) \
-    : "0" ((_isr_cookie)), "1" ((_flash_mask)) \
-    ); \
-  }
+	{ \
+		register u32 _flash_mask = 0; \
+		__asm__ __volatile__ ( \
+			"cmpwi %0,0\n" \
+			"beq 1f\n" \
+			"mfmsr %1\n" \
+			"ori %1,%1,0x8000\n" \
+			"mtmsr %1\n" \
+			"rlwinm %1,%1,0,17,15\n" \
+			"mtmsr %1\n" \
+			"1:" \
+			: "=r" ((_isr_cookie)), "=&r" ((_flash_mask)) \
+			: "0" ((_isr_cookie)), "1" ((_flash_mask)) \
+			: "memory" \
+		); \
+	}
 
 #define _CPU_FPR_Enable() \
 { register u32 _val = 0; \

--- a/gc/ogc/machine/processor.h
+++ b/gc/ogc/machine/processor.h
@@ -102,7 +102,7 @@
 { __asm__ __volatile__  ("mtmsr %0" : "=&r" ((_msr_value)) : "0" ((_msr_value))); }
 
 #define _CPU_ISR_Enable() \
-	{ \
+	do { \
 		register u32 _val = 0; \
 		__asm__ __volatile__ ( \
 			"mfmsr %0\n" \
@@ -111,10 +111,10 @@
 			: "=&r" ((_val)) : "0" ((_val)) \
 			: : "memory" \
 		); \
-	}
+	} while (0)
 
 #define _CPU_ISR_Disable( _isr_cookie ) \
-	{ \
+	do { \
 		register u32 _disable_mask = 0; \
 		_isr_cookie = 0; \
 		__asm__ __volatile__ ( \
@@ -126,10 +126,10 @@
 			: "0" ((_isr_cookie)), "1" ((_disable_mask)) \
 			: "memory" \
 		); \
-	}
+	} while (0)
 
 #define _CPU_ISR_Restore( _isr_cookie )  \
-	{ \
+	do { \
 		register u32 _enable_mask = 0; \
 		__asm__ __volatile__ ( \
 			"cmpwi %0,0\n" \
@@ -142,10 +142,10 @@
 			: "0"((_isr_cookie)),"1" ((_enable_mask)) \
 			: "memory" \
 		); \
-	}
+	} while (0)
 
 #define _CPU_ISR_Flash( _isr_cookie ) \
-	{ \
+	do { \
 		register u32 _flash_mask = 0; \
 		__asm__ __volatile__ ( \
 			"cmpwi %0,0\n" \
@@ -160,7 +160,7 @@
 			: "0" ((_isr_cookie)), "1" ((_flash_mask)) \
 			: "memory" \
 		); \
-	}
+	} while (0)
 
 #define _CPU_FPR_Enable() \
 { register u32 _val = 0; \

--- a/libogc/arqmgr.c
+++ b/libogc/arqmgr.c
@@ -136,7 +136,7 @@ u32 ARQM_GetStackPointer(void)
 {
 	u32 level,tmp;
 
-	_CPU_ISR_Disable(level)
+	_CPU_ISR_Disable(level);
 	tmp = __ARQMStackPointer[__ARQMStackLocation];
 	_CPU_ISR_Restore(level);
 
@@ -147,7 +147,7 @@ u32 ARQM_GetFreeSize(void)
 {
 	u32 level,tmp;
 
-	_CPU_ISR_Disable(level)
+	_CPU_ISR_Disable(level);
 	tmp = __ARQMFreeBytes;
 	_CPU_ISR_Restore(level);
 


### PR DESCRIPTION
This PR adds "memory" clobbers to the ISR disable/restore/enable/flash operations, which were sorely needed but missing. Inspired by the debugging work on #103, though it won't necessarily fix that (it may or may not, and we may want to make other changes too) it's something that needs to be done regardless since interrupts can fire as a result of these and regions protected by disabling interrupts should be treated as critical sections.

While I was there I also made the style at least consistent.