### PR TITLE
lwp_watchdog.h: remove unmatched parenthesis from tick_nanosecs()

### DIFF
--- a/gc/ogc/lwp_watchdog.h
+++ b/gc/ogc/lwp_watchdog.h
@@ -38,7 +38,7 @@
 #define ticks_to_nanosecs(ticks)	((((u64)(ticks)*8000)/(u64)(TB_TIMER_CLOCK/125)))
 
 #define tick_microsecs(ticks)		((((u64)(ticks)*8)/(u64)(TB_TIMER_CLOCK/125))%TB_USPERSEC)
-#define tick_nanosecs(ticks)		((((u64)(ticks)*8000)/(u64)(TB_TIMER_CLOCK/125)))%TB_NSPERSEC)
+#define tick_nanosecs(ticks)		((((u64)(ticks)*8000)/(u64)(TB_TIMER_CLOCK/125))%TB_NSPERSEC)
 
 #define secs_to_ticks(sec)			((u64)(sec)*(TB_TIMER_CLOCK*1000))
 #define millisecs_to_ticks(msec)	((u64)(msec)*(TB_TIMER_CLOCK))


### PR DESCRIPTION
Trying to use this macro caused a compiler error (unless I left out a parenthesis from my code).