### PR TITLE
revert es.h renamed property to fix build on some applications

### DIFF
--- a/gc/ogc/es.h
+++ b/gc/ogc/es.h
@@ -144,7 +144,7 @@ typedef struct _tmd {
 	u16 title_version;
 	u16 num_contents;
 	u16 boot_index;
-	u16 fill2;
+	u16 fill3;
 	// content records follow
 	// C99 flexible array
 	tmd_content contents[];


### PR DESCRIPTION
it is better to leave it alone untill we know exactly what the field is anyway