### PR TITLE
system: check reset button state correctly on gamecube

### DIFF
--- a/libogc/system.c
+++ b/libogc/system.c
@@ -446,14 +446,14 @@ static void __RSWHandler(u32 irq, void* ctx)
 	do  {
 		now = gettime();
 		if(diff_usec(hold_down,now)>=100) break;
-	} while(!(_piReg[0]&0x10000));
+	} while(!SYS_ResetButtonDown());
 
-	if(_piReg[0]&0x10000) {
+	if(SYS_ResetButtonDown()){
 		__MaskIrq(IRQMASK(IRQ_PI_RSW));
-
 		if(__RSWCallback) {
 			__RSWCallback(irq, ctx);
 		}
+		__UnmaskIrq(IRQMASK(IRQ_PI_RSW));
 	}
 	_piReg[0] = 2;
 }


### PR DESCRIPTION
also unmask the irq after callback so pressing it again re-triggers the irq

Things to note : 
* the registry always contains the state of the reset button ( 0 = pressed, 1 = unpressed ) and the IRQ only triggers when going from 1 to 0 (it doesn't trigger when holding it, or releasing it)
* the while loop i left as is, besides it now checking on reset not being pressed (to deal with debounce)
* callback is executed when the button is pressed (unlike before where it only executed if it wasn't pressed)
* IRQ is unmasked after the callback so the IRQ can be triggered again ( and therefor acts the same on GC and Wii )