### PR TITLE
dsp: fix typo when yielding from certain messages (#130)

### DIFF
--- a/libogc/dsp.c
+++ b/libogc/dsp.c
@@ -248,7 +248,7 @@ static void __dsp_def_taskcb(void)
 					while(DSP_CheckMailTo());
 
 					__dsp_exectask(__dsp_currtask,__dsp_rudetask);
-					__dsp_currtask->flags = DSPTASK_YIELD;
+					__dsp_currtask->state = DSPTASK_YIELD;
 					__dsp_currtask = __dsp_rudetask;
 					__dsp_rudetask = NULL;
 					__dsp_rudetask_pend = FALSE;


### PR DESCRIPTION
pointed out by pokechu22, and does indeed seem wrong