### PR TITLE
aesnd: fix AESND_Reset. free voices & fix cmpi of unsigned short.

### DIFF
--- a/libaesnd/aesndlib.c
+++ b/libaesnd/aesndlib.c
@@ -485,7 +485,12 @@ void AESND_Reset(void)
 		do {
 			_CPU_ISR_Flash(level);
 		} while(__aesnddspinit);
-
+		
+#if defined(HW_DOL)
+		u32 i=0;
+		for(;i<MAX_VOICES;i++) 
+			AR_Free(NULL);
+#endif
 		__aesndinit = 0;
 	}
 	_CPU_ISR_Restore(level);

--- a/libaesnd/dspcode/dspmixer.s
+++ b/libaesnd/dspcode/dspmixer.s
@@ -156,8 +156,9 @@ recv_cmd:
 	
 	cmpi	$acc1.m,#0x0100
 	jeq		send_samples
-	
-	cmpi	$acc1.m,#0xdead
+
+	lri		$acc0.m,#0xdead
+	cmp
 	jeq		task_terminate
 	
 wait_commands:


### PR DESCRIPTION
courtesy to Extrems & @muff1n1634  for providing the fix
tested with 
[AESNDResetFix.zip](https://github.com/devkitPro/libogc/files/10960099/AESNDResetFix.zip)
