### PR TITLE
console: calculate in the x & y offset when writing to the framebuffer

### DIFF
--- a/libogc/console.c
+++ b/libogc/console.c
@@ -80,11 +80,13 @@ void __console_vipostcb(u32 retraceCnt)
 {
 	u32 ycnt,xcnt, fb_stride;
 	u32 *fb,*ptr;
+	u32 offset;
 
 	do_xfb_copy = TRUE;
 
-	ptr = curr_con->destbuffer;
-	fb = VIDEO_GetCurrentFramebuffer()+(curr_con->target_y*curr_con->tgt_stride) + curr_con->target_x*VI_DISPLAY_PIX_SZ;
+	offset = (curr_con->target_y*curr_con->tgt_stride) + curr_con->target_x*VI_DISPLAY_PIX_SZ;
+	ptr = curr_con->destbuffer+offset;
+	fb = VIDEO_GetCurrentFramebuffer()+offset;
 	fb_stride = curr_con->tgt_stride/4 - (curr_con->con_xres/VI_DISPLAY_PIX_SZ);
 
 	for(ycnt=curr_con->con_yres;ycnt>0;ycnt--)
@@ -115,7 +117,8 @@ static void __console_drawc(int c)
 	if(!curr_con) return;
 	con = curr_con;
 
-	ptr = (unsigned int*)(con->destbuffer + ( con->con_stride *  con->cursor_row * FONT_YSIZE ) + ((con->cursor_col * FONT_XSIZE / 2) * 4));
+	ptr = (unsigned int*)(con->destbuffer + ( con->con_stride * con->cursor_row * FONT_YSIZE ) + ((con->cursor_col * FONT_XSIZE / 2) * 4) +
+						 (curr_con->target_y*curr_con->tgt_stride) + curr_con->target_x*VI_DISPLAY_PIX_SZ);
 	pbits = &con->font[c * FONT_YSIZE];
 	nextline = con->con_stride/4 - 4;
 	fgcolor = con->foreground;
@@ -266,6 +269,10 @@ void __console_init(void *framebuffer,int xstart,int ystart,int xres,int yres,in
 	con->con_stride = con->tgt_stride = stride;
 	con->target_x = xstart;
 	con->target_y = ystart;
+	con->cursor_row = 0;
+	con->cursor_col = 0;
+	con->saved_row = 0;
+	con->saved_col = 0;
 
 	con->font = console_font_8x16;
 


### PR DESCRIPTION
the x/y offsets were completely unused when doing a regular CON_Init, as it was just writing it to the framebuffer