### PR TITLE
add support for Dolphin debug messages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -149,7 +149,7 @@ OGCOBJ		:=	\
 			console_font_8x16.o timesupp.o lock_supp.o usbgecko.o usbmouse.o \
 			sbrk.o malloc_lock.o kprintf.o stm.o aes.o sha.o ios.o es.o isfs.o usb.o network_common.o \
 			sdgecko_io.o sdgecko_buf.o gcsd.o argv.o network_wii.o wiisd.o conf.o usbstorage.o \
-			texconv.o wiilaunch.o
+			texconv.o wiilaunch.o sys_report.o
 
 #---------------------------------------------------------------------------------
 MODOBJ		:=	freqtab.o mixer.o modplay.o semitonetab.o gcmodplay.o

--- a/gc/ogc/system.h
+++ b/gc/ogc/system.h
@@ -322,7 +322,6 @@ s32 SYS_SetPeriodicAlarm(syswd_t thealarm,const struct timespec *tp_start,const 
 */
 s32 SYS_RemoveAlarm(syswd_t thealarm);
 
-
 /*! \fn s32 SYS_CancelAlarm(syswd_t thealarm)
 \brief Cancel the alarm, but do not remove from the list of contexts.
 \param[in] thealarm identifier to the alram context to be canceled
@@ -330,6 +329,22 @@ s32 SYS_RemoveAlarm(syswd_t thealarm);
 \return 0 on succuess, non-zero on error
 */
 s32 SYS_CancelAlarm(syswd_t thealarm);
+
+/* \fn void SYS_STDIO_Report(bool use_stdout)
+\brief redirect stderr to Dolphin OSReport uart
+\param[in] use_stdout also redirect stdout for use of printf
+
+*/
+void SYS_STDIO_Report(bool use_stdout);
+
+/*! \fn void SYS_Report (char const *const fmt_, ...)
+\brief write formatted string to Dolphin OSReport uart
+
+*/
+
+void SYS_Report (char const *const fmt_, ...);
+
+
 
 u32 SYS_GetCounterBias(void);
 void SYS_SetCounterBias(u32 bias);

--- a/libogc/sys_report.c
+++ b/libogc/sys_report.c
@@ -1,0 +1,95 @@
+/*-------------------------------------------------------------
+
+osreport.c -- Bulk-only USB mass storage support
+
+Copyright (C) 2023
+Dave Murphy (WinterMute) <davem@devkitpro.org>
+
+This software is provided 'as-is', without any express or implied
+warranty.  In no event will the authors be held liable for any
+damages arising from the use of this software.
+
+Permission is granted to anyone to use this software for any
+purpose, including commercial applications, and to alter it and
+redistribute it freely, subject to the following restrictions:
+
+1.	The origin of this software must not be misrepresented; you
+must not claim that you wrote the original software. If you use
+this software in a product, an acknowledgment in the product
+documentation would be appreciated but is not required.
+
+2.	Altered source versions must be plainly marked as such, and
+must not be misrepresented as being the original software.
+
+3.	This notice may not be removed or altered from any source
+distribution.
+
+-------------------------------------------------------------*/
+
+#include <sys/iosupport.h>
+#include <stdio.h>
+#include <stdarg.h>
+
+#include "exi.h"
+
+static ssize_t __uart_write(const char *buffer,size_t len)
+{
+	u32 cmd,ret;
+
+	if(EXI_Lock(EXI_CHANNEL_0,EXI_DEVICE_1,NULL)==0) return 0;
+	if(EXI_Select(EXI_CHANNEL_0,EXI_DEVICE_1,EXI_SPEED8MHZ)==0) {
+		EXI_Unlock(EXI_CHANNEL_0);
+		return len;
+	}
+
+	ret = 0;
+	cmd = 0xa0010000;
+	if(EXI_Imm(EXI_CHANNEL_0,&cmd,4,EXI_WRITE,NULL)==0) ret |= 0x01;
+	if(EXI_Sync(EXI_CHANNEL_0)==0) ret |= 0x02;
+	if(EXI_ImmEx(EXI_CHANNEL_0,(void *)buffer,len,EXI_WRITE)==0) ret |= 0x04;
+	if(EXI_Deselect(EXI_CHANNEL_0)==0) ret |= 0x08;
+	if(EXI_Unlock(EXI_CHANNEL_0)==0) ret |= 0x10;
+
+	return len;
+}
+
+static ssize_t __uart_stdio_write(struct _reent *r, void *fd, const char *ptr, size_t len)
+{
+	__uart_write(ptr,len);
+	return len;
+}
+static const devoptab_t dotab_uart = {
+	.name    = "uart",
+	.write_r = __uart_stdio_write,
+};
+
+void SYS_STDIO_Report(bool use_stdout)
+{
+	fflush(stderr);
+	devoptab_list[STD_ERR] = &dotab_uart;
+	setvbuf(stderr, NULL, _IONBF, 0);
+	if(use_stdout)
+	{
+		fflush(stdout);
+		devoptab_list[STD_OUT] = &dotab_uart;
+		setvbuf(stdout, NULL, _IONBF, 0);
+	}
+}
+
+static char __outstr[256];
+
+void SYS_Report (char const *const fmt_, ...)
+{
+
+	int len;
+
+	va_list args;
+
+	va_start(args, fmt_);
+	len=vsnprintf(__outstr,256,fmt_,args);
+	va_end(args);
+
+	__uart_write(__outstr, len);
+
+}
+

--- a/libogc/sys_report.c
+++ b/libogc/sys_report.c
@@ -1,6 +1,6 @@
 /*-------------------------------------------------------------
 
-osreport.c -- Bulk-only USB mass storage support
+sys_report.c -- Support for printing to Dolphin debug UART
 
 Copyright (C) 2023
 Dave Murphy (WinterMute) <davem@devkitpro.org>


### PR DESCRIPTION
Adds SYS_Report to write messages to Dolphin's debug uart.
SYS_STDIO_Report redirects stderr (and optionally stdout) to the uart.

