### PR TITLE
Fixed setting cmdblk state incorrectly on cancels

### DIFF
--- a/libogc/dvd.c
+++ b/libogc/dvd.c
@@ -842,7 +842,7 @@ static void __dvd_statebusycb(s32 result)
 		__dvd_canceling = 0;
 		block = __dvd_executing;
 		__dvd_executing = &__dvd_dummycmdblk;
-		__dvd_executing->state = 10;
+		block->state = 10;
 		if(block->cb) block->cb(-3,block);
 		if(__dvd_cancelcallback) __dvd_cancelcallback(0,block);
 		__dvd_stateready();


### PR DESCRIPTION
This fixes a bug in `__dvd_statebusycb`, where if a DVD command block is cancelled, it incorrectly updates the state on the dummy command block instead of the executing one.