### PR TITLE
libasnd: Fixed the swapped stereo problem

### DIFF
--- a/libasnd/dsp_mixer/dsp_mixer.s
+++ b/libasnd/dsp_mixer/dsp_mixer.s
@@ -834,10 +834,10 @@ stereo_8bits:
 	lrri $ACL0, @$AR2
 	mrr  $ACM0, $ACL0
 	andi $ACM0, #0xff00
-	mrr  $AXH1, $ACM0
+	mrr  $AXH0, $ACM0
 	lsl  $ACC0, #8
 
-	mrr  $AXH0, $ACL0
+	mrr  $AXH1, $ACL0
 	jmp	out_samp
 
 mono_16bits:
@@ -852,8 +852,8 @@ stereo_16bits:
 
 // 16 bits stereo
 
-	lrri $AXH1, @$AR2
 	lrri $AXH0, @$AR2
+	lrri $AXH1, @$AR2
 	jmp	out_samp
 
 mono_8bits_unsigned:
@@ -892,17 +892,17 @@ stereo_8bits_unsigned:
 	xori $ACM0, #0x8080 // convert unsigned->signed
 	mrr  $ACL0, $ACM0
 	andi $ACM0, #0xff00
-	mrr  $AXH1, $ACM0
+	mrr  $AXH0, $ACM0
 	lsl  $ACC0, #8
 
-	mrr  $AXH0, $ACL0
+	mrr  $AXH1, $ACL0
 	jmp	out_samp
 
 stereo_16bits_le:
 
 // 16 bits stereo little-endian
-	lrri $ACM1, @$AR2
 	lrri $ACM0, @$AR2
+	lrri $ACM1, @$AR2
 	mrr  $ACL1, $ACM1
 	mrr  $ACL0, $ACM0
 	lsl  $ACC1, #8 // byteswap


### PR DESCRIPTION
I managed to fix the swapped stereo channels problem in the libasnd library. I found this problem accidentally while listened audio with hearphones plugged to the TV.

Fixes #169