### PR TITLE
gx: add GX_GetTexObjLOD()

### DIFF
--- a/gc/ogc/gx.h
+++ b/gc/ogc/gx.h
@@ -4096,6 +4096,21 @@ u16 GX_GetTexObjHeight(const GXTexObj* obj);
 u16 GX_GetTexObjWidth(const GXTexObj* obj);
 
 /*!
+ * \fn void GX_GetTexObjLOD(const GXTexObj* obj, f32 *minlod, f32 *maxlod)
+ * \brief Returns the min and max LOD values for the texture object \a obj.
+ *
+ * \note Use GX_InitTexObjLOD(), GX_InitTexObjMinLOD() or GX_InitTexObjMaxLOD()
+ * to initialize the texture minimum and maximum LOD.
+ *
+ * \param[in] obj ptr to a texture object
+ * \param[out] minlod minimum LOD value from 0.0 - 10.0 inclusive
+ * \param[out] maxlod maximum LOD value from 0.0 - 10.0 inclusive
+ *
+ * \return none
+ */
+void GX_GetTexObjLOD(const GXTexObj* obj, f32 *minlod, f32 *maxlod);
+
+/*!
  * \fn void GX_GetTexObjAll(const GXTexObj* obj, void** image_ptr, u16* width, u16* height, u8* format, u8* wrap_s, u8* wrap_t, u8* mipmap);
  * \brief Returns the parameters described by a texture object. Texture objects are used to describe all the parameters associated with a texture, including size, format, wrap modes, filter modes, etc. Texture objects are initialized using either GX_InitTexObj() or, for color index format textures, GX_InitTexObjCI().
  *

--- a/libogc/gx.c
+++ b/libogc/gx.c
@@ -3027,6 +3027,12 @@ u16 GX_GetTexObjWidth(const GXTexObj *obj)
 	return (((const struct __gx_texobj*)obj)->tex_size & 0x3ff) + 1;
 }
 
+void GX_GetTexObjLOD(const GXTexObj *obj, f32 *minlod, f32 *maxlod)
+{
+	const struct __gx_texobj *ptr = (const struct __gx_texobj*)obj;
+	*minlod = (ptr->tex_lod & 0xff) / 16.0f;
+	*maxlod = _SHIFTR(ptr->tex_lod, 8, 8) / 16.0f;
+}
 
 void GX_GetTexObjAll(const GXTexObj *obj, void** image_ptr, u16* width, u16* height,
                      u8* format, u8* wrap_s, u8* wrap_t, u8* mipmap)


### PR DESCRIPTION
These values are written into the texture object by GX_InitTexObjLOD(), GX_InitTexObjMinLOD() and GX_InitTexObjMaxLOD() but there was no getter for them.

I tested the function like this:

```c
    {   
        GXTexObj tex;
        GX_InitTexObj(&tex, NULL, 12, 23, GX_TF_RGB565, GX_REPEAT, GX_REPEAT, GX_TRUE);
        GX_InitTexObjLOD(&tex, GX_LIN_MIP_LIN, GX_LIN_MIP_LIN, 2.5, 7.0, 0, GX_ENABLE, GX_ENABLE, GX_ANISO_1);  
        f32 minlod, maxlod;                                                                            
        GX_GetTexObjLOD(&tex, &minlod, &maxlod);                                                       
        fprintf(stderr, "Minlod %f, maxlod %f\n", minlod, maxlod);                                     
    }                                                                                                  
```
And verified that the code prints 2.5 and 7.0 (I also tried a few other values, from 0.0 to 10.0).