### PR TITLE
gx: use correct constant name for PASSCLR operation

### DIFF
--- a/libogc/gx.c
+++ b/libogc/gx.c
@@ -3858,7 +3858,7 @@ void GX_SetTevOp(u8 tevstage,u8 mode)
 			break;
 		case GX_PASSCLR:
 			GX_SetTevColorIn(tevstage,GX_CC_ZERO,GX_CC_ZERO,GX_CC_ZERO,defcolor);
-			GX_SetTevAlphaIn(tevstage,GX_CC_A2,GX_CC_A2,GX_CC_A2,defalpha);
+			GX_SetTevAlphaIn(tevstage,GX_CA_ZERO,GX_CA_ZERO,GX_CA_ZERO,defalpha);
 			break;
 	}
 	GX_SetTevColorOp(tevstage,GX_TEV_ADD,GX_TB_ZERO,GX_CS_SCALE_1,GX_TRUE,GX_TEVPREV);


### PR DESCRIPTION
In the alpha input we should use only GX_CA_* registers.  Both GX_CC_A2 and GX_CA_ZERO evaluate to 7, so this is just a cosmetic issue.

The existing error is probably the result of a misunderstanding during reverse engineering.