### PR TITLE
Network fixes

### DIFF
--- a/gc/network.h
+++ b/gc/network.h
@@ -222,13 +222,12 @@ struct sockaddr_in {
   u8 sin_family;
   u16 sin_port;
   struct in_addr sin_addr;
-  s8 sin_zero[8];
 };
 
 struct sockaddr {
   u8 sa_len;
   u8 sa_family;
-  s8 sa_data[14];
+  s8 sa_data[6];
 };
 
 struct hostent {

--- a/libogc/network_wii.c
+++ b/libogc/network_wii.c
@@ -1093,7 +1093,6 @@ s32 net_getsockname(s32 s, struct sockaddr *addr, socklen_t *addrlen)
 	s32 ret;
 
 	if (net_ip_top_fd < 0) return -ENXIO;
-	if (*addrlen<8) return -ENOMEM;
 
 	if (!addr) return -EINVAL;
 	if (!addrlen) return -EINVAL;

--- a/libogc/network_wii.c
+++ b/libogc/network_wii.c
@@ -820,12 +820,12 @@ s32 net_bind(s32 s, struct sockaddr *name, socklen_t namelen)
 	if (net_ip_top_fd < 0) return -ENXIO;
 	if (name->sa_family != AF_INET) return -EAFNOSUPPORT;
 
-	name->sa_len = 8;
+	name->sa_len = sizeof(struct sockaddr_in);
 
 	memset(params, 0, sizeof(struct bind_params));
 	params->socket = s;
 	params->has_name = 1;
-	memcpy(params->name, name, 8);
+	memcpy(params->name, name, sizeof(struct sockaddr_in));
 
 	ret = _net_convert_error(IOS_Ioctl(net_ip_top_fd, IOCTL_SO_BIND, params, sizeof (struct bind_params), NULL, 0));
 	debug_printf("net_bind(%d, %p)=%d\n", s, name, ret);
@@ -860,14 +860,14 @@ s32 net_accept(s32 s, struct sockaddr *addr, socklen_t *addrlen)
 	if (net_ip_top_fd < 0) return -ENXIO;
 
 	if (!addr) return -EINVAL;
-	addr->sa_len = 8;
+	addr->sa_len = sizeof(struct sockaddr_in);
 	addr->sa_family = AF_INET;
 
 	if (!addrlen) return -EINVAL;
 
-	if (*addrlen < 8) return -ENOMEM;
+	if (*addrlen < sizeof(struct sockaddr_in)) return -ENOMEM;
 
-	*addrlen = 8;
+	*addrlen = sizeof(struct sockaddr_in);
 
 	*_socket = s;
 	debug_printf("calling ios_ioctl(%d, %d, %p, %d)\n", net_ip_top_fd, IOCTL_SO_ACCEPT, _socket, 4);
@@ -884,9 +884,9 @@ s32 net_connect(s32 s, struct sockaddr *addr, socklen_t addrlen)
 
 	if (net_ip_top_fd < 0) return -ENXIO;
 	if (addr->sa_family != AF_INET) return -EAFNOSUPPORT;
-	if (addrlen < 8) return -EINVAL;
+	if (addrlen < sizeof(struct sockaddr_in)) return -EINVAL;
 
-	addrlen = 8;
+	addrlen = sizeof(struct sockaddr_in);
 
 	addr->sa_len = addrlen;
 
@@ -1097,11 +1097,11 @@ s32 net_getsockname(s32 s, struct sockaddr *addr, socklen_t *addrlen)
 	if (!addr) return -EINVAL;
 	if (!addrlen) return -EINVAL;
 
-	if (*addrlen < 8) return -ENOMEM;
+	if (*addrlen < sizeof(struct sockaddr_in)) return -ENOMEM;
 
-	addr->sa_len = 8;
+	addr->sa_len = sizeof(struct sockaddr_in);
 	addr->sa_family = AF_INET;
-	*addrlen = 8;
+	*addrlen = sizeof(struct sockaddr_in);
 	*_socket = s;
 
 	ret = _net_convert_error(IOS_Ioctl(net_ip_top_fd, IOCTL_SO_GETSOCKNAME, _socket, 4, addr, *addrlen));


### PR DESCRIPTION
Two commits, I suggest to not squash them.

Having this structure being 16 bytes long causes net_sendto not to work; setting it to 8 bytes means that we can get rid of a few magic numbers in libogc's code (which actually show that the structure is meant to be 8 bytes only).
    
Changes have been tested on both a real Wii and on Dolphin, using the sockettest and udptest from wii-examples.
