### PR TITLE
Clear used wiimotes

### DIFF
--- a/wiiuse/wpad.c
+++ b/wiiuse/wpad.c
@@ -1738,6 +1738,9 @@ s32 WPAD_Shutdown(void)
 		__wpads_listen[i].sock = NULL;
 	}
 
+	__wpads_active = 0;
+	__wpads_used = 0;
+
 	__wiiuse_sensorbar_enable(0);
 	_CPU_ISR_Restore(level);
 

--- a/wiiuse/wpad.c
+++ b/wiiuse/wpad.c
@@ -950,9 +950,10 @@ static s8 __wpad_connreqCB(void *arg,struct bd_addr *pad_addr,u8 *cod,u8 link_ty
 		if(!bd_addr_cmp(pad_addr,BD_ADDR_ANY)) {
 			confslot = GetActiveSlot(pad_addr);
 			if (confslot < CONF_PAD_MAX_ACTIVE) {
+				BD_ADDR_FROM_BYTES(&bdaddr,__wpad_devs.active[confslot].bdaddr);
 				name = (u8 *)__wpad_devs.active[confslot].name;
 				WIIUSE_DEBUG("Active pad '%s' found in slot %d", name, confslot);
-				if (!(__wpads_used & (1<<confslot)))
+				if (!(__wpads_used & (1<<confslot)) || bd_addr_cmp(pad_addr,&bdaddr))
 					slot = confslot;
 				else
 					WIIUSE_DEBUG("Slot %d taken! Finding new slot", confslot);


### PR DESCRIPTION
Wiimotes were not being cleared from the active bitmask and were taking their own slots if WPAD was shutdown and reinit in the same app. This clears the active and used bitmasks, ensuring those slots are properly marked as not in use upon shutdown, and also adds in a check to ensure that the owner of a slot can always get it back.