### PR TITLE
console: fix writing out of bounds and writing unused memory

### DIFF
--- a/gc/ogc/console.h
+++ b/gc/ogc/console.h
@@ -100,7 +100,7 @@ void CON_GetPosition(int *cols, int *rows);
  * \fn CON_EnableGecko(int channel, int safe)
  * \brief Enable or disable the USB gecko console.
  *
- * \param[in] channel EXI channel, or -1 �to disable the gecko console
+ * \param[in] channel EXI channel, or -1 to disable the gecko console
  * \param[in] safe If true, use safe mode (wait for peer)
  *
  * \return none

--- a/gc/ogc/console.h
+++ b/gc/ogc/console.h
@@ -80,7 +80,7 @@ s32 CON_InitEx(GXRModeObj *rmode, s32 conXOrigin,s32 conYOrigin,s32 conWidth,s32
  * \fn CON_GetMetrics(int *cols, int *rows)
  * \brief retrieve the columns and rows of the current console
  *
- * \param[out] cols,rows number of columns and rows of the current console, in tiles, 1-indexed.
+ * \param[out] cols,rows number of columns and rows of the current console, in tiles
  *
  * \return none
  */
@@ -90,7 +90,7 @@ void CON_GetMetrics(int *cols, int *rows);
  * \fn CON_GetPosition(int *col, int *row)
  * \brief retrieve the current cursor position of the current console
  *
- * \param[out] col,row current cursor position, in tiles, 1-indexed.
+ * \param[out] col,row current cursor position, in tiles, 1-indexed
  *
  * \return none
  */
@@ -198,10 +198,10 @@ void consoleSetFont(PrintConsole* console, ConsoleFont* font);
 /**
  * @brief Sets the print window.
  * @param console Console to set, if NULL it will set the current console window.
- * @param x X location of the window, in tiles, 1-indexed.
- * @param y Y location of the window, in tiles, 1-indexed.
- * @param width Width of the window, in tiles, 1-indexed.
- * @param height Height of the window, in tiles, 1-indexed.
+ * @param x X location of the window, in tiles, 1-indexed
+ * @param y Y location of the window, in tiles, 1-indexed
+ * @param width Width of the window, in tiles
+ * @param height Height of the window, in tiles
  */
 void consoleSetWindow(PrintConsole* console, unsigned int x, unsigned int y, unsigned int width, unsigned int height);
 

--- a/gc/ogc/console.h
+++ b/gc/ogc/console.h
@@ -55,9 +55,9 @@
  * \brief Initializes the console subsystem with given parameters
  *
  * \param[in] framebuffer pointer to the framebuffer used for drawing the characters
- * \param[in] xstart,ystart start position of the console output in pixel
- * \param[in] xres,yres size of the console in pixel
- * \param[in] stride size of one line of the framebuffer in bytes
+ * \param[in] xstart,ystart start position of the console output, in pixels
+ * \param[in] xres,yres size of the console, in pixels
+ * \param[in] stride size of one line of the framebuffer, in bytes
  *
  * \return none
  */
@@ -69,8 +69,8 @@ void CON_Init(void *framebuffer,int xstart,int ystart,int xres,int yres,int stri
  * \param[in] rmode pointer to the video/render mode configuration
  * \param[in] conXOrigin starting pixel in X direction of the console output on the external framebuffer
  * \param[in] conYOrigin starting pixel in Y direction of the console output on the external framebuffer
- * \param[in] conWidth width of the console output 'window' to be drawn
- * \param[in] conHeight height of the console output 'window' to be drawn
+ * \param[in] conWidth width of the console output 'window' to be drawn, in pixels
+ * \param[in] conHeight height of the console output 'window' to be drawn, in pixels
  *
  * \return 0 on success, <0 on error
  */
@@ -80,7 +80,7 @@ s32 CON_InitEx(GXRModeObj *rmode, s32 conXOrigin,s32 conYOrigin,s32 conWidth,s32
  * \fn CON_GetMetrics(int *cols, int *rows)
  * \brief retrieve the columns and rows of the current console
  *
- * \param[out] cols,rows number of columns and rows of the current console
+ * \param[out] cols,rows number of columns and rows of the current console, in tiles, 1-indexed.
  *
  * \return none
  */
@@ -90,7 +90,7 @@ void CON_GetMetrics(int *cols, int *rows);
  * \fn CON_GetPosition(int *col, int *row)
  * \brief retrieve the current cursor position of the current console
  *
- * \param[out] col,row current cursor position
+ * \param[out] col,row current cursor position, in tiles, 1-indexed.
  *
  * \return none
  */
@@ -100,7 +100,7 @@ void CON_GetPosition(int *cols, int *rows);
  * \fn CON_EnableGecko(int channel, int safe)
  * \brief Enable or disable the USB gecko console.
  *
- * \param[in] channel EXI channel, or -1 ¨to disable the gecko console
+ * \param[in] channel EXI channel, or -1 ï¿½to disable the gecko console
  * \param[in] safe If true, use safe mode (wait for peer)
  *
  * \return none
@@ -152,22 +152,24 @@ typedef struct PrintConsole
 	ConsoleFont font;        ///< Font of the console
 
 	void *destbuffer;        ///< Framebuffer address
-	int con_xres,con_yres,con_stride;
-	int target_x,target_y, tgt_stride;
+	int con_xres, con_yres;  ///< Console buffer width/height, in pixels
+	int con_stride;          ///< Size of one row in the console buffer, in bytes
+	int target_x, target_y;  ///< Target buffer x/y offset to start the console, in pixels
+	int tgt_stride;          ///< Size of one row in the target buffer, in bytes
 
-	int cursorX;             ///< Current X location of the cursor (as a tile offset by default)
-	int cursorY;             ///< Current Y location of the cursor (as a tile offset by default)
+	int cursorX;             ///< Current X location of the cursor in the window, in tiles, 1-indexed: 1 <= cursorX <= windowWidth, cursorX > windowWidth wraps to the next line and resets to cursorX = 1
+	int cursorY;             ///< Current Y location of the cursor in the window, in tiles, 1-indexed
 
 	int prevCursorX;         ///< Internal state
 	int prevCursorY;         ///< Internal state
 
-	int con_cols;            ///< Width of the console hardware layer in characters
-	int con_rows;            ///< Height of the console hardware layer in characters
+	int con_cols;            ///< Width of the console hardware layer, in characters (amount of tiles)
+	int con_rows;            ///< Height of the console hardware layer, in characters (amount of tiles)
 
-	int windowX;             ///< Window X location in characters (not implemented)
-	int windowY;             ///< Window Y location in characters (not implemented)
-	int windowWidth;         ///< Window width in characters (not implemented)
-	int windowHeight;        ///< Window height in characters (not implemented)
+	int windowX;             ///< Window X location, in tiles, 1-indexed, 1 <= windowX < con_cols
+	int windowY;             ///< Window Y location, in tiles, 1-indexed
+	int windowWidth;         ///< Window width, in amount of tiles, 1 <= windowWidth <= con_cols
+	int windowHeight;        ///< Window height, in amount of tiles
 
 	int tabSize;             ///< Size of a tab
 	unsigned int fg;         ///< Foreground color
@@ -196,10 +198,10 @@ void consoleSetFont(PrintConsole* console, ConsoleFont* font);
 /**
  * @brief Sets the print window.
  * @param console Console to set, if NULL it will set the current console window.
- * @param x X location of the window.
- * @param y Y location of the window.
- * @param width Width of the window.
- * @param height Height of the window.
+ * @param x X location of the window, in tiles, 1-indexed.
+ * @param y Y location of the window, in tiles, 1-indexed.
+ * @param width Width of the window, in tiles, 1-indexed.
+ * @param height Height of the window, in tiles, 1-indexed.
  */
 void consoleSetWindow(PrintConsole* console, unsigned int x, unsigned int y, unsigned int width, unsigned int height);
 

--- a/gc/ogc/console.h
+++ b/gc/ogc/console.h
@@ -55,9 +55,9 @@
  * \brief Initializes the console subsystem with given parameters
  *
  * \param[in] framebuffer pointer to the framebuffer used for drawing the characters
- * \param[in] xstart,ystart start position of the console output, in pixels
- * \param[in] xres,yres size of the console, in pixels
- * \param[in] stride size of one line of the framebuffer, in bytes
+ * \param[in] xstart,ystart start position of the console output in pixels
+ * \param[in] xres,yres size of the console in pixels
+ * \param[in] stride size of one line of the framebuffer in bytes
  *
  * \return none
  */
@@ -69,8 +69,8 @@ void CON_Init(void *framebuffer,int xstart,int ystart,int xres,int yres,int stri
  * \param[in] rmode pointer to the video/render mode configuration
  * \param[in] conXOrigin starting pixel in X direction of the console output on the external framebuffer
  * \param[in] conYOrigin starting pixel in Y direction of the console output on the external framebuffer
- * \param[in] conWidth width of the console output 'window' to be drawn, in pixels
- * \param[in] conHeight height of the console output 'window' to be drawn, in pixels
+ * \param[in] conWidth width of the console output 'window' to be drawn in pixels
+ * \param[in] conHeight height of the console output 'window' to be drawn in pixels
  *
  * \return 0 on success, <0 on error
  */
@@ -80,7 +80,7 @@ s32 CON_InitEx(GXRModeObj *rmode, s32 conXOrigin,s32 conYOrigin,s32 conWidth,s32
  * \fn CON_GetMetrics(int *cols, int *rows)
  * \brief retrieve the columns and rows of the current console
  *
- * \param[out] cols,rows number of columns and rows of the current console, in tiles
+ * \param[out] cols,rows number of columns and rows of the current console in tiles
  *
  * \return none
  */
@@ -90,7 +90,7 @@ void CON_GetMetrics(int *cols, int *rows);
  * \fn CON_GetPosition(int *col, int *row)
  * \brief retrieve the current cursor position of the current console
  *
- * \param[out] col,row current cursor position, in tiles, 1-indexed
+ * \param[out] col,row current cursor position in tiles, 1-indexed
  *
  * \return none
  */
@@ -163,8 +163,8 @@ typedef struct PrintConsole
 	int prevCursorX;         ///< Internal state
 	int prevCursorY;         ///< Internal state
 
-	int con_cols;            ///< Width of the console hardware layer in characters (amount of tiles)
-	int con_rows;            ///< Height of the console hardware layer in characters (amount of tiles)
+	int con_cols;            ///< Width of the console hardware layer in characters (aka tiles)
+	int con_rows;            ///< Height of the console hardware layer in characters (aka tiles)
 
 	int windowX;             ///< Window X location in tiles, 1-indexed, 1 <= windowX < con_cols
 	int windowY;             ///< Window Y location in tiles, 1-indexed

--- a/gc/ogc/console.h
+++ b/gc/ogc/console.h
@@ -56,7 +56,7 @@
  *
  * \param[in] framebuffer pointer to the framebuffer used for drawing the characters
  * \param[in] xstart,ystart start position of the console output in pixels
- * \param[in] xres,yres size of the console in pixels
+ * \param[in] xres,yres size of the console in pixels. Truncated to a multiple of font size if not already one
  * \param[in] stride size of one line of the framebuffer in bytes
  *
  * \return none
@@ -69,8 +69,8 @@ void CON_Init(void *framebuffer,int xstart,int ystart,int xres,int yres,int stri
  * \param[in] rmode pointer to the video/render mode configuration
  * \param[in] conXOrigin starting pixel in X direction of the console output on the external framebuffer
  * \param[in] conYOrigin starting pixel in Y direction of the console output on the external framebuffer
- * \param[in] conWidth width of the console output 'window' to be drawn in pixels
- * \param[in] conHeight height of the console output 'window' to be drawn in pixels
+ * \param[in] conWidth width of the console output 'window' to be drawn in pixels. Truncated to a multiple of font width if not already one
+ * \param[in] conHeight height of the console output 'window' to be drawn in pixels. Truncated to a multiple of font height if not already one
  *
  * \return 0 on success, <0 on error
  */

--- a/gc/ogc/console.h
+++ b/gc/ogc/console.h
@@ -152,24 +152,24 @@ typedef struct PrintConsole
 	ConsoleFont font;        ///< Font of the console
 
 	void *destbuffer;        ///< Framebuffer address
-	int con_xres, con_yres;  ///< Console buffer width/height, in pixels
-	int con_stride;          ///< Size of one row in the console buffer, in bytes
-	int target_x, target_y;  ///< Target buffer x/y offset to start the console, in pixels
-	int tgt_stride;          ///< Size of one row in the target buffer, in bytes
+	int con_xres, con_yres;  ///< Console buffer width/height in pixels
+	int con_stride;          ///< Size of one row in the console buffer in bytes
+	int target_x, target_y;  ///< Target buffer x/y offset to start the console in pixels
+	int tgt_stride;          ///< Size of one row in the target buffer in bytes
 
-	int cursorX;             ///< Current X location of the cursor in the window, in tiles, 1-indexed: 1 <= cursorX <= windowWidth, cursorX > windowWidth wraps to the next line and resets to cursorX = 1
-	int cursorY;             ///< Current Y location of the cursor in the window, in tiles, 1-indexed
+	int cursorX;             ///< Current X location of the cursor in the window in tiles, 1-indexed: 1 <= cursorX <= windowWidth, cursorX > windowWidth wraps to the next line and resets to cursorX = 1
+	int cursorY;             ///< Current Y location of the cursor in the window in tiles, 1-indexed
 
 	int prevCursorX;         ///< Internal state
 	int prevCursorY;         ///< Internal state
 
-	int con_cols;            ///< Width of the console hardware layer, in characters (amount of tiles)
-	int con_rows;            ///< Height of the console hardware layer, in characters (amount of tiles)
+	int con_cols;            ///< Width of the console hardware layer in characters (amount of tiles)
+	int con_rows;            ///< Height of the console hardware layer in characters (amount of tiles)
 
-	int windowX;             ///< Window X location, in tiles, 1-indexed, 1 <= windowX < con_cols
-	int windowY;             ///< Window Y location, in tiles, 1-indexed
-	int windowWidth;         ///< Window width, in amount of tiles, 1 <= windowWidth <= con_cols
-	int windowHeight;        ///< Window height, in amount of tiles
+	int windowX;             ///< Window X location in tiles, 1-indexed, 1 <= windowX < con_cols
+	int windowY;             ///< Window Y location in tiles, 1-indexed
+	int windowWidth;         ///< Window width in tiles, 1 <= windowWidth <= con_cols
+	int windowHeight;        ///< Window height in tiles
 
 	int tabSize;             ///< Size of a tab
 	unsigned int fg;         ///< Foreground color
@@ -198,10 +198,10 @@ void consoleSetFont(PrintConsole* console, ConsoleFont* font);
 /**
  * @brief Sets the print window.
  * @param console Console to set, if NULL it will set the current console window.
- * @param x X location of the window, in tiles, 1-indexed
- * @param y Y location of the window, in tiles, 1-indexed
- * @param width Width of the window, in tiles
- * @param height Height of the window, in tiles
+ * @param x X location of the window in tiles, 1-indexed
+ * @param y Y location of the window in tiles, 1-indexed
+ * @param width Width of the window in tiles
+ * @param height Height of the window in tiles
  */
 void consoleSetWindow(PrintConsole* console, unsigned int x, unsigned int y, unsigned int width, unsigned int height);
 

--- a/libogc/console.c
+++ b/libogc/console.c
@@ -149,7 +149,7 @@ PrintConsole currentCopy;
 
 PrintConsole* currentConsole = &currentCopy;
 
-static void *__console_offset_by_pixels(void *ptr, s32 dy_pixels, u32 stride_bytes, s32 dx_pixels)
+static inline void *__console_offset_by_pixels(void *ptr, s32 dy_pixels, u32 stride_bytes, s32 dx_pixels)
 {
 	const s32 dy_bytes = dy_pixels * stride_bytes;
 	const s32 dx_bytes = dx_pixels * VI_DISPLAY_PIX_SZ;
@@ -158,12 +158,12 @@ static void *__console_offset_by_pixels(void *ptr, s32 dy_pixels, u32 stride_byt
 
 // cursor_y and cursor_x are 1-indexed tile offsets (to start of tile), window offsets are a type of cursor
 // window/console dimensions are a count of tiles, but 0-indexed
-static void *__console_offset_by_cursor(void *ptr, u32 cursor_y, u32 stride_bytes, u32 cursor_x)
+static inline void *__console_offset_by_cursor(void *ptr, u32 cursor_y, u32 stride_bytes, u32 cursor_x)
 {
 	return __console_offset_by_pixels(ptr, (cursor_y - 1) * FONT_YSIZE, stride_bytes, (cursor_x - 1) * FONT_XSIZE);
 }
 
-static void *__console_get_buffer_start_ptr()
+static inline void *__console_get_buffer_start_ptr()
 {
 	if(!currentConsole)
 		return NULL;
@@ -183,7 +183,7 @@ static void *__console_get_buffer_start_ptr()
 		: __console_offset_by_pixels(currentConsole->destbuffer, currentConsole->target_y, currentConsole->tgt_stride, currentConsole->target_x);
 }
 
-static void *__console_get_window_start_ptr()
+static inline void *__console_get_window_start_ptr()
 {
 	PrintConsole *con;
 	if( !(con = currentConsole) )
@@ -192,7 +192,7 @@ static void *__console_get_window_start_ptr()
 	return __console_offset_by_cursor(__console_get_buffer_start_ptr(), con->windowY, con->con_stride, con->windowX);
 }
 
-static void *__console_get_cursor_start_ptr()
+static inline void *__console_get_cursor_start_ptr()
 {
 	PrintConsole *con;
 	if( !(con = currentConsole) )

--- a/libogc/console.c
+++ b/libogc/console.c
@@ -213,13 +213,16 @@ void __console_vipostcb(u32 retraceCnt)
 	u8 *fb,*ptr;
 
 	do_xfb_copy = true;
-	ptr = currentConsole->destbuffer;
+	ptr = _console_buffer;
 	fb = __console_offset_by_pixels(VIDEO_GetCurrentFramebuffer(), currentConsole->target_y, currentConsole->tgt_stride, currentConsole->target_x);
 
+	const u32 line_count = currentConsole->con_yres;
+	const u32 bytes_per_line = currentConsole->con_xres * VI_DISPLAY_PIX_SZ;
+
 	// Copies 1 line of pixels at a time
-	for(u16 ycnt = 0; ycnt < currentConsole->con_yres; ycnt++)
+	for(u16 ycnt = 0; ycnt < line_count; ycnt++)
 	{
-		memcpy(fb, ptr, currentConsole->con_xres * VI_DISPLAY_PIX_SZ);
+		memcpy(fb, ptr, bytes_per_line);
 		ptr += currentConsole->con_stride;
 		fb += currentConsole->tgt_stride;
 	}
@@ -1059,6 +1062,9 @@ ssize_t __console_write(struct _reent *r,void *fd,const char *ptr, size_t len)
 
 void CON_Init(void *framebuffer,int xstart,int ystart,int xres,int yres,int stride)
 {
+	// force xres, yres to be multiples of font size
+	xres = (xres / FONT_XSIZE) * FONT_XSIZE;
+	yres = (yres / FONT_YSIZE) * FONT_YSIZE;
 	__console_init(framebuffer,xstart,ystart,xres,yres,stride);
 }
 
@@ -1068,6 +1074,9 @@ s32 CON_InitEx(GXRModeObj *rmode, s32 conXOrigin,s32 conYOrigin,s32 conWidth,s32
 	if(_console_buffer)
 		free(_console_buffer);
 	
+	// force conWidth, conHeight to be multiples of font size
+	conWidth = (conWidth / FONT_XSIZE) * FONT_XSIZE;
+	conHeight = (conHeight / FONT_YSIZE) * FONT_YSIZE;
 	_console_buffer = malloc(conWidth*conHeight*VI_DISPLAY_PIX_SZ);
 	if(!_console_buffer) return -1;
 

--- a/libogc/console.c
+++ b/libogc/console.c
@@ -340,7 +340,7 @@ to convert from 'an amount of tiles' to 'the end of the final tile' (aka 'the st
 simply add 1 to the 'amount of tiles' value
 Examples:
 a cursor points to (the start of) tile 3, how many tiles to fill to clear until (the start of) tile 7 ?
--> fill tile 3, 4, 5, 6 (= 4 tiles)
+-> fill tile 3, 4, 5, 6 (= 4 tiles = 7 - 3)
 a cursor points to (the start of) tile 2 in an area with 5 tiles, how many tiles to fill to clear until the end ?
 -> fill tile 2, 3, 4, 5 (= 4 tiles = 5 - 2 + 1, because '5' here is an amount, not an offset)
 */
@@ -351,7 +351,7 @@ static void __console_clear_line(int line, int from, int to)
 	
 	if( !(con = currentConsole) ) return;
 
-	// Each character is FONT_XSIZE * VI_DISPLAY_PIX_SZ wide
+	// Each character is FONT_XSIZE * VI_DISPLAY_PIX_SZ bytes wide
 	const u32 line_width = (to - from) * FONT_XSIZE * VI_DISPLAY_PIX_SZ;
 
 	unsigned int bgcolor = con->bg;

--- a/libogc/console.c
+++ b/libogc/console.c
@@ -247,8 +247,10 @@ static void __console_drawc(int c)
 	ptr = __console_get_cursor_start_ptr();
 
 	pbits = &con->font.gfx[c * FONT_YSIZE];
-	// con_stride is in bytes, but we increment ptr which isn't a byte pointer
-	// and the work in the loop already increments ptr 4 times before needing to go to the next row
+	// con_stride is in bytes, but we increment ptr which is an int pointer
+	// -> we have to divide to not skip over rows we want to write to
+	// the work in the loop already writes 4 ints before going to the next row
+	// -> subtract that 4 here, so nextline can be directly added to ptr later
 	nextline = con->con_stride/sizeof(*ptr) - 4;
 
 	fgcolor = currentConsole->fg;


### PR DESCRIPTION
Adds precision to the expected values of various arguments/results of the console API
New internal helper functions for commonly repeated (tedious and prone to mistakes) pattern
More comments for non-intuitive/non-obvious implementation decisions that had to be done due to the mixing of "units"

NOT TESTED ON HARDWARE (or in any use), but logically sound (more than the previous mixed results, at least)