### PR TITLE
Small bug fix.

### DIFF
--- a/libogc/exception.c
+++ b/libogc/exception.c
@@ -61,7 +61,7 @@ typedef struct _framerec {
 } frame_rec, *frame_rec_t;
 
 static void *exception_xfb = (void*)0xC1700000;			//we use a static address above ArenaHi.
-static int reload_timer = 1000;
+static int reload_timer = -1;
 
 void __exception_sethandler(u32 nExcept, void (*pHndl)(frame_context*));
 
@@ -203,9 +203,11 @@ static void waitForReload(void)
 	u32 level;
 	
 	PAD_Init();
+
+	kprintf("\n\n\tPress RESET (or Z on your GameCube Controller) to reload");
 	
 	if(reload_timer > 0) {
-		kprintf("\n\n\tPress RESET (or Z on your GameCube Controller) to skip\n\n\tReloading in %d seconds", reload_timer/50);
+		kprintf("\n\n\tReloading in %d seconds", reload_timer/50);
 	}
 
 	while ( 1 )

--- a/libogc/exception.c
+++ b/libogc/exception.c
@@ -213,7 +213,7 @@ static void waitForReload(void)
 	while ( 1 )
 	{
 		if(reload_timer > 0) {
-			kprintf("\r\tReloading in %d seconds ", reload_timer/50);
+			kprintf("\x1b[2K\tReloading in %d seconds", reload_timer/50);
 		}
 		PAD_ScanPads();
 

--- a/libogc/exception.c
+++ b/libogc/exception.c
@@ -214,6 +214,7 @@ static void waitForReload(void)
 	{
 		if(reload_timer > 0) {
 			kprintf("\x1b[2K\tReloading in %d seconds", reload_timer/50);
+			kprintf("\r\tReloading in %d seconds ", reload_timer/50);
 		}
 		PAD_ScanPads();
 

--- a/libogc/exception.c
+++ b/libogc/exception.c
@@ -204,26 +204,20 @@ static void waitForReload(void)
 	
 	PAD_Init();
 
-	kprintf("\n\n\tPress RESET (or Z on your GameCube Controller) to reload");
-	
-	if(reload_timer > 0) {
-		kprintf("\n\n\tReloading in %d seconds", reload_timer/50);
-	}
+	kprintf("\n\n\tPress RESET (or Z on your GameCube Controller) to reload\n\n");
 
 	while ( 1 )
 	{
 		if(reload_timer > 0) {
-			kprintf("\x1b[2K\tReloading in %d seconds", reload_timer/50);
-			kprintf("\r\tReloading in %d seconds ", reload_timer/50);
+			kprintf("\x1b[2K\r\tReloading in %d seconds", reload_timer/50);
 		}
 		PAD_ScanPads();
 
 		int buttonsDown = PAD_ButtonsDown(0);
 
-		if( (buttonsDown & PAD_TRIGGER_Z) || SYS_ResetButtonDown() || 
-			reload_timer == 0 )
+		if( (buttonsDown & PAD_TRIGGER_Z) || SYS_ResetButtonDown() || reload_timer == 0 )
 		{
-			kprintf("\n\n\tReload\n\n\n");
+			kprintf("\n\tReload\n\n\n");
 			_CPU_ISR_Disable(level);
 			__reload ();
 		}

--- a/libogc/exception.c
+++ b/libogc/exception.c
@@ -61,7 +61,7 @@ typedef struct _framerec {
 } frame_rec, *frame_rec_t;
 
 static void *exception_xfb = (void*)0xC1700000;			//we use a static address above ArenaHi.
-static int reload_timer = -1;
+static int reload_timer = 1000;
 
 void __exception_sethandler(u32 nExcept, void (*pHndl)(frame_context*));
 
@@ -201,14 +201,18 @@ void __exception_setreload(int t)
 static void waitForReload(void)
 {
 	u32 level;
-
+	
 	PAD_Init();
 	
-	if(reload_timer > 0)
-		kprintf("\n\tReloading in %d seconds\n", reload_timer/50);
+	if(reload_timer > 0) {
+		kprintf("\n\n\tPress RESET (or Z on your GameCube Controller) to skip\n\n\tReloading in %d seconds", reload_timer/50);
+	}
 
 	while ( 1 )
 	{
+		if(reload_timer > 0) {
+			kprintf("\r\tReloading in %d seconds ", reload_timer/50);
+		}
 		PAD_ScanPads();
 
 		int buttonsDown = PAD_ButtonsDown(0);
@@ -216,7 +220,7 @@ static void waitForReload(void)
 		if( (buttonsDown & PAD_TRIGGER_Z) || SYS_ResetButtonDown() || 
 			reload_timer == 0 )
 		{
-			kprintf("\n\tReload\n\n\n");
+			kprintf("\n\n\tReload\n\n\n");
 			_CPU_ISR_Disable(level);
 			__reload ();
 		}


### PR DESCRIPTION
Exception handler now automatically returns to the HBC after timeout + Added a message that tells the user that they can press reset (or Z on their GameCube Controller) to skip timeout because users tended to just unplug their Wiis from power.