### PR TITLE
define GX_TEXMAPNULL as GX_TEXMAP_NULL

### DIFF
--- a/gc/ogc/gx.h
+++ b/gc/ogc/gx.h
@@ -672,6 +672,7 @@
 #define GX_TEXMAP7				7			/*!< Texture map slot 7 */
 #define GX_MAX_TEXMAP			8
 #define GX_TEXMAP_NULL			0xff			/*!< No texmap */
+#define GX_TEXMAPNULL			GX_TEXMAP_NULL
 #define GX_TEXMAP_DISABLE		0x100			/*!< Disable texmap lookup for this texmap slot (use bitwise OR with a texture map slot). */
 /*! @} */
 


### PR DESCRIPTION
all the other NULL values that are used in GX_SetTevOrder (i.e. GX_TEXCOORDNULL, GX_COLORNULL) dont have underscores before null except for GX_TEXMAP_NULL and not only is that out of place its also annoying cos i can never remember whether GX_TEXCOORDNULL is the one with the underscore or GX_TEXMAP_NULL