### PR TITLE
Wii Motion Plus Fixed

### DIFF
--- a/gc/wiiuse/wpad.h
+++ b/gc/wiiuse/wpad.h
@@ -228,6 +228,9 @@ void WPAD_Expansion(int chan, struct expansion_t *exp);
 void WPAD_PadStatus(int chan);
 bool WPAD_IsBatteryCritical(int chan);
 
+s32 WPAD_HasMotionPlus(s32 chan);
+#define WPAD_EXP_MOTION_PLUS 5
+
 #ifdef __cplusplus
    }
 #endif /* __cplusplus */

--- a/wiiuse/motion_plus.c
+++ b/wiiuse/motion_plus.c
@@ -30,7 +30,7 @@ static void wiiuse_probe_motion_plus_check2(struct wiimote_t *wm, ubyte *data, u
 
 static void wiiuse_probe_motion_plus_check1(struct wiimote_t *wm, ubyte *data, uword len)
 {
-	if (data[1] != 0x05)
+	if (data[5] != 0x05)
 	{
 		WIIMOTE_DISABLE_STATE(wm, WIIMOTE_STATE_MPLUS_PRESENT);
 		WIIMOTE_DISABLE_STATE(wm, WIIMOTE_STATE_EXP_HANDSHAKE);
@@ -45,7 +45,7 @@ static void wiiuse_probe_motion_plus_check1(struct wiimote_t *wm, ubyte *data, u
 void wiiuse_probe_motion_plus(struct wiimote_t *wm)
 {
 	ubyte *buf = __lwp_wkspace_allocate(MAX_PAYLOAD);
-	wiiuse_read_data(wm, buf, WM_EXP_MOTION_PLUS_MODE, 2, wiiuse_probe_motion_plus_check1);
+	wiiuse_read_data(wm, buf, WM_EXP_ID, 6, wiiuse_probe_motion_plus_check1);
 }
 
 void wiiuse_motion_plus_check(struct wiimote_t *wm,ubyte *data,uword len)

--- a/wiiuse/wpad.c
+++ b/wiiuse/wpad.c
@@ -89,7 +89,7 @@ static vs32 __wpads_bonded = 0;
 static u32 __wpad_idletimeout = 300;
 static vu32 __wpads_active = 0;
 static vu32 __wpads_used = 0;
-static wiimote **__wpads = NULL;
+wiimote **__wpads = NULL;
 static wiimote_listen __wpads_listen[WPAD_MAX_DEVICES] = {0};
 static WPADData wpaddata[WPAD_MAX_DEVICES] = {0};
 static struct _wpad_cb __wpdcb[WPAD_MAX_DEVICES] = {0};
@@ -2045,4 +2045,11 @@ bool WPAD_IsBatteryCritical(int chan)
 {
 	if(chan<0 || chan>=WPAD_MAX_DEVICES) return false;
 	return WIIMOTE_IS_SET(__wpads[chan],WIIMOTE_STATE_BATTERY_CRITICAL);
+}
+
+int WPAD_HasMotionPlus(s32 chan) {
+    if (__wpads && __wpads[chan]) __wpads[chan]->state &= ~0x000020;
+    if (__wpads == NULL) return 0;
+    if (__wpads[chan] == NULL) return 0;
+    return (__wpads[chan]->state & 0x100000) ? 1 : 0;
 }


### PR DESCRIPTION
Hey,

I was messing around with Motion Plus on my Wii and noticed it never worked in any homebrew app. Looked into the libogc source and found some bugs in motion_plus.c that explain why.

The probe function was reading from WM_EXP_MOTION_PLUS_MODE (0x04A600FE) instead of WM_EXP_ID (0x04A400FA) which are completely different memory banks on the Wiimote. On top of that it was only reading 2 bytes when the identifier is 6 bytes long, which meant data[5] was always an out of bounds read. And then it was checking data[1] != 0x05 when the correct byte to check is data[5] since 0x05 is the last byte of the Motion Plus identifier (00 00 A6 20 00 05).

Fixed all three in motion_plus.c. Also added WPAD_HasMotionPlus() in wpad.c since there was no public way to check if Motion Plus is present, and added WPAD_EXP_MOTION_PLUS as a constant to match the existing WPAD_EXP_NUNCHUK and WPAD_EXP_CLASSIC.

Tested on real Wii hardware with both the original Motion Plus accessory and a built-in Wiimote Plus. Gyro data works and detection works correctly.