### PR TITLE
Fix clock_gettime() and tick_nanosecs() macro

### DIFF
--- a/gc/ogc/lwp_watchdog.h
+++ b/gc/ogc/lwp_watchdog.h
@@ -15,8 +15,8 @@
 #define ticks_to_microsecs(ticks)	PPCTicksToUs(ticks)
 #define ticks_to_nanosecs(ticks)	PPCTicksToNs(ticks)
 
-#define tick_microsecs(ticks)		(PPCTicksToUs(ticks)%TB_USPERSEC)
-#define tick_nanosecs(ticks)		(PPCTicksToNs(ticks)%TB_NSPERSEC)
+#define tick_microsecs(ticks)		PPCTicksToUs((ticks)%PPC_TIMER_CLOCK)
+#define tick_nanosecs(ticks)		PPCTicksToNs((ticks)%PPC_TIMER_CLOCK)
 
 #define secs_to_ticks(sec)			((u64)(sec)*PPC_TIMER_CLOCK)
 #define millisecs_to_ticks(msec)	PPCMsToTicks(msec)


### PR DESCRIPTION
clock_gettime() uses the tick_nanosecs() macro to extract the sub-second component of a time expressed in PPC ticks, and returns the sub-second component expressed in nanoseconds.

To do so, it relied on the PPCTicksToNs() function, which will overflow and return incorrect results if its argument is sufficiently large (in my case it was 50446082889576108). This in turn causes clock_gettime() to return the wrong number of nanoseconds, which confuses applications because they occasionally see the time jump back.

We fix it by using a simpler formula for tick_nanosecs(), which is guaranteed not to overflow on u64 variables.