### PR TITLE
gx: fix application hang on GPU FIFO overflow

### DIFF
--- a/libogc/gx.c
+++ b/libogc/gx.c
@@ -389,7 +389,7 @@ static void __GXOverflowHandler(void)
 		_gxoverflowsuspend = 1;
 		_gxoverflowcount++;
 		__GX_WriteFifoIntEnable(GX_DISABLE,GX_ENABLE);
-		__GX_WriteFifoIntReset(GX_TRUE,GX_FALSE);
+		__GX_WriteFifoIntReset(GX_TRUE,GX_TRUE);
 		LWP_SuspendThread(_gxcurrentlwp);
 	}
 }


### PR DESCRIPTION
This fixes a bug which began to manifest itself after the switch to Tuxedo, though we haven't been able to find anything wrong with Tuxedo's implementation -- we cannot even rule out that this is due to a compiler / toolkit update, though this seems less likely.

The bug happens when the FIFO gets full and both the overflow and underflow status bits are set: the overflow handler suspends (with LWP_SuspendThread()) the graphical thread, which often is the application main thread, after which the underflow handler is never invoked anymore, so the graphical thread remains stopped. Other threads continue to work (wiimotes do connect to the Wii). Why exactly the underflow handler is not invoked anymore is unclear.

The solution (or rather workaround) is to clear both the FIFO overflow bit (obviously) and the underflow one, despite the fact that this should have already been done by the underflow handler.

Another workaround which has been shown to be working is adding an `else` before the check for the overflow bits, in order not to immediately invoke the overflow handler if we just invoked the underflow one. Should we for some reason need to revert this commit, that is another path that could be taken.

Fixes: https://github.com/devkitPro/libogc/issues/262