### PR TITLE
console: store the cache after clearing a framebuffer

### DIFF
--- a/libogc/console.c
+++ b/libogc/console.c
@@ -1079,6 +1079,7 @@ void CON_Init(void *framebuffer,int xstart,int ystart,int xres,int yres,int stri
 	for(int i=0; i<yres*stride/4; i++) {
 		ptr[i] = colorTable[0];
 	}
+	DCStoreRange(framebuffer, yres * stride);
 
 	// xstart and ystart are offsets within the provided framebuffer
 	// reduce xres and yres accordingly to prevent OOB writes


### PR DESCRIPTION
This fixes a screen corruption issue on the wiimote example, where
adding a call to fatInitDefault() right at the beginning of main()
causes the upper 1/4 of the screen to be dirty (mostly green).

To reproduce this, one needs to have a USB drive connected, formatted
with NTFS:
- libdvm will try to initialize the drive
- it will create a cache for it (128KB)
- seeing that it's NTFS and that there's no driver for the NTFS format,
  it will destroy the disk
- the memory associated with the disk is freed, and then reused for the
  framebuffer